### PR TITLE
feat(api): migrate lifecycle routes to /api/ namespace and add deployment reconciliation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,13 @@ load-tinyllama-cpu:
 	curl -s -X POST http://localhost:$(API_PORT)/api/deployments/tinyllama-1.1b-chat-vllm-cpu-trainbox/load
 
 load-qwen3-27b-fp8:
-	curl -s -X POST http://localhost:$(API_PORT)/api/deployments/qwen3-27b-fp8-vllm-trainbox/load
+	curl -s -X POST http://localhost:$(API_PORT)/api/deployments/qwen3.6-27b-fp8-vllm-trainbox/load
 
 unload-tinyllama-cpu:
 	curl -s -X POST http://localhost:$(API_PORT)/api/deployments/tinyllama-1.1b-chat-vllm-cpu-trainbox/unload
+
+unload-qwen3-27b-fp8:
+	curl -s -X POST http://localhost:$(API_PORT)/api/deployments/qwen3.6-27b-fp8-vllm-trainbox/unload
 
 # -------------------------------------------------------------------
 # Docker
@@ -137,6 +140,7 @@ help:
 	@echo "  load-tinyllama-cpu     - Load TinyLlama CPU deployment via API"
 	@echo "  load-qwen3-27b-fp8     - Load Qwen 3.6 27B FP8 deployment via API"
 	@echo "  unload-tinyllama-cpu   - Unload TinyLlama CPU deployment via API"
+	@echo "  unload-qwen3-27b-fp8   - Unload Qwen 3.6 27B FP8 deployment via API"
 	@echo ""
 	@echo "Docker:"
 	@echo "  docker-ps              - List switchyard-managed containers"
@@ -155,6 +159,6 @@ help:
 
 .PHONY: tunnel dev test lint typecheck quality \
 	api-deployments api-models \
-	load-tinyllama-cpu load-qwen3-27b-fp8 unload-tinyllama-cpu \
+	load-tinyllama-cpu load-qwen3-27b-fp8 unload-tinyllama-cpu unload-qwen3-27b-fp8 \
 	docker-ps docker-clean stop status help
 .DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -62,25 +62,19 @@ quality: lint typecheck test
 # API Curl Commands
 # -------------------------------------------------------------------
 api-deployments:
-	curl -s http://localhost:$(API_PORT)/deployments
+	curl -s http://localhost:$(API_PORT)/api/deployments
 
 api-models:
 	curl -s http://localhost:$(API_PORT)/v1/models
 
 load-tinyllama-cpu:
-	curl -s -X POST http://localhost:$(API_PORT)/deployments/load \
-		-H 'Content-Type: application/json' \
-		-d '{"deployment":"tinyllama-1.1b-chat-vllm-cpu-trainbox"}'
+	curl -s -X POST http://localhost:$(API_PORT)/api/deployments/tinyllama-1.1b-chat-vllm-cpu-trainbox/load
 
 load-qwen3-27b-fp8:
-	curl -s -X POST http://localhost:$(API_PORT)/deployments/load \
-		-H 'Content-Type: application/json' \
-		-d '{"deployment":"qwen3-27b-fp8-vllm-trainbox"}'
+	curl -s -X POST http://localhost:$(API_PORT)/api/deployments/qwen3-27b-fp8-vllm-trainbox/load
 
 unload-tinyllama-cpu:
-	curl -s -X POST http://localhost:$(API_PORT)/deployments/unload \
-		-H 'Content-Type: application/json' \
-		-d '{"deployment":"tinyllama-1.1b-chat-vllm-cpu-trainbox"}'
+	curl -s -X POST http://localhost:$(API_PORT)/api/deployments/tinyllama-1.1b-chat-vllm-cpu-trainbox/unload
 
 # -------------------------------------------------------------------
 # Docker
@@ -138,7 +132,7 @@ help:
 	@echo "  stop                   - Stop the API server"
 	@echo ""
 	@echo "API Curl Commands:"
-	@echo "  api-deployments        - GET /deployments"
+	@echo "  api-deployments        - GET /api/deployments"
 	@echo "  api-models             - GET /v1/models"
 	@echo "  load-tinyllama-cpu     - Load TinyLlama CPU deployment via API"
 	@echo "  load-qwen3-27b-fp8     - Load Qwen 3.6 27B FP8 deployment via API"

--- a/switchyard-api/config.yaml
+++ b/switchyard-api/config.yaml
@@ -68,7 +68,7 @@ models:
       served_model_name: tinyllama-1.1b-chat
 
 deployments:
-  qwen3-27b-fp8-vllm-trainbox:
+  qwen3.6-27b-fp8-vllm-trainbox:
     model: qwen3-27b-fp8
     runtime: vllm
     host: trainbox

--- a/switchyard-api/src/switchyard/app.py
+++ b/switchyard-api/src/switchyard/app.py
@@ -16,7 +16,6 @@ import httpx
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel
 
 from switchyard.adapters.vllm import register_vllm
 from switchyard.config.loader import ConfigLoader, resolve_deployment
@@ -127,18 +126,6 @@ def create_app(config_overrides: dict[str, Any] | None = None) -> FastAPI:
     _register_routes(app)
 
     return app
-
-
-class LoadModelRequest(BaseModel):
-    """Request body for loading a deployment."""
-
-    deployment: str
-
-
-class UnloadModelRequest(BaseModel):
-    """Request body for unloading a deployment."""
-
-    deployment: str
 
 
 def _register_routes(app: FastAPI) -> None:
@@ -345,12 +332,20 @@ def _register_routes(app: FastAPI) -> None:
 
 
 def _mask_sensitive_args(args: dict[str, Any]) -> dict[str, Any]:
-    """Mask sensitive runtime args (tokens, keys, secrets) in the detail response."""
-    sensitive_keys = {"hf_token", "api_key", "secret_key", "password", "token"}
+    """Mask sensitive runtime args recursively.
+
+    Normalizes keys by replacing '-' with '_' and redacts any key containing
+    'token', 'secret', 'password', or 'api_key'. Handles nested dicts including
+    extra_args.
+    """
+    sensitive_substrings = {"token", "secret", "password", "api_key"}
     masked: dict[str, Any] = {}
     for key, value in args.items():
-        if key in sensitive_keys and value is not None:
+        normalized = key.replace("-", "_")
+        if any(substr in normalized for substr in sensitive_substrings):
             masked[key] = "***redacted***"
+        elif isinstance(value, dict):
+            masked[key] = _mask_sensitive_args(value)
         else:
             masked[key] = value
     return masked

--- a/switchyard-api/src/switchyard/app.py
+++ b/switchyard-api/src/switchyard/app.py
@@ -152,31 +152,107 @@ def _register_routes(app: FastAPI) -> None:
         """Health check endpoint."""
         return {"status": "ok"}
 
-    @app.post("/deployments/load", status_code=202)
-    async def load_deployment(body: LoadModelRequest) -> dict[str, Any]:
+    # ── /api/ deployment lifecycle routes ──────────────────────────
+
+    @app.get("/api/deployments")
+    async def list_deployments() -> list[dict[str, Any]]:
+        """List all configured deployments with current status."""
+        results: list[dict[str, Any]] = []
+        for dep_name, dep_cfg in config.deployments.items():
+            try:
+                info = manager.state.get(dep_name)
+                status = info.status
+            except KeyError:
+                status = "stopped"
+            results.append({
+                "deployment_name": dep_name,
+                "model": dep_cfg.model,
+                "runtime": dep_cfg.runtime,
+                "host": dep_cfg.host,
+                "status": status,
+            })
+        return results
+
+    @app.get("/api/deployments/{deployment}")
+    async def get_deployment(deployment: str) -> dict[str, Any]:
+        """Get deployment detail: configured intent + small status summary."""
+        if deployment not in config.deployments:
+            raise HTTPException(
+                status_code=404,
+                detail=f"deployment {deployment!r} not found in config",
+            )
+        dep_cfg = config.deployments[deployment]
+        try:
+            info = manager.state.get(deployment)
+            status = info.status
+        except KeyError:
+            status = "stopped"
+
+        # Resolve store paths for the detail response
+        resolved = resolve_deployment(config, deployment)
+
+        return {
+            "deployment_name": deployment,
+            "model": dep_cfg.model,
+            "runtime": dep_cfg.runtime,
+            "host": dep_cfg.host,
+            "placement": {
+                "accelerator_ids": dep_cfg.placement.accelerator_ids
+                if dep_cfg.placement
+                else [],
+            },
+            "model_host_path": resolved.model_host_path,
+            "model_container_path": resolved.model_container_path,
+            "runtime_args": _mask_sensitive_args(resolved.runtime_args),
+            "status": status,
+        }
+
+    @app.get("/api/deployments/{deployment}/status")
+    async def get_deployment_status(deployment: str) -> dict[str, Any]:
+        """Get live operational status for a deployment."""
+        if deployment not in config.deployments:
+            raise HTTPException(
+                status_code=404,
+                detail=f"deployment {deployment!r} not found in config",
+            )
+        try:
+            info = manager.state.get(deployment)
+            return {
+                "deployment_name": info.model_name,
+                "status": info.status,
+                "port": info.port,
+                "container_id": info.container_id,
+                "started_at": info.started_at.isoformat(),
+            }
+        except KeyError:
+            return {
+                "deployment_name": deployment,
+                "status": "stopped",
+            }
+
+    @app.post("/api/deployments/{deployment}/load", status_code=202)
+    async def load_deployment(deployment: str) -> dict[str, Any]:
         """Load a deployment (async).
 
         Resolves the deployment config and starts the container via the
         backend adapter. Returns immediately; poll status for progress.
         """
-        deployment_name = body.deployment
-        if deployment_name not in config.deployments:
+        if deployment not in config.deployments:
             raise HTTPException(
                 status_code=404,
-                detail=f"deployment {deployment_name!r} not found in config",
+                detail=f"deployment {deployment!r} not found in config",
             )
 
-        # Resolve the deployment and start it via the lifecycle manager.
-        resolved = resolve_deployment(config, deployment_name)
+        resolved = resolve_deployment(config, deployment)
 
         try:
-            info = await manager.load_model(deployment_name, resolved)
+            info = await manager.load_model(deployment, resolved)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc))
         except RuntimeError as exc:
             raise HTTPException(
                 status_code=500,
-                detail=f"failed to start deployment {deployment_name!r}: {exc}",
+                detail=f"failed to start deployment {deployment!r}: {exc}",
             )
 
         return {
@@ -187,46 +263,38 @@ def _register_routes(app: FastAPI) -> None:
             "container_id": info.container_id,
         }
 
-    @app.post("/deployments/unload")
-    async def unload_deployment(body: UnloadModelRequest) -> dict[str, str]:
+    @app.post("/api/deployments/{deployment}/unload")
+    async def unload_deployment(deployment: str) -> dict[str, str]:
         """Unload a deployment."""
-        deployment_name = body.deployment
-        try:
-            await manager.unload_model(deployment_name)
-        except KeyError:
+        if deployment not in config.deployments:
             raise HTTPException(
                 status_code=404,
-                detail=f"deployment {deployment_name!r} not found",
+                detail=f"deployment {deployment!r} not found in config",
             )
-
-        return {"deployment_name": deployment_name, "status": "stopped"}
-
-    @app.get("/deployments")
-    async def list_deployments() -> list[dict[str, Any]]:
-        """List all deployments with status."""
-        names = manager.state.list_deployments()
-        return [
-            {
-                "deployment_name": info.model_name,
-                "backend": info.backend,
-                "port": info.port,
-                "status": info.status,
-                "started_at": info.started_at,
-            }
-            for info in (manager.state.get(n) for n in names)
-        ]
-
-    @app.get("/deployments/{deployment}/status")
-    async def get_deployment_status(deployment: str) -> dict[str, str]:
-        """Get status of a single deployment."""
         try:
-            info = manager.state.get(deployment)
+            await manager.unload_model(deployment)
         except KeyError:
-            raise HTTPException(
-                status_code=404, detail=f"deployment {deployment!r} not found",
-            )
+            # Deployment not in state (already stopped/unloaded)
+            return {"deployment_name": deployment, "status": "stopped"}
 
-        return {"deployment_name": info.model_name, "status": info.status}
+        return {"deployment_name": deployment, "status": "stopped"}
+
+    @app.post("/api/proxy/{deployment}/{path:path}")
+    async def proxy_passthrough(
+        request: Request, deployment: str, path: str,
+    ) -> Any:
+        """Scoped passthrough to backend-specific endpoints.
+
+        The path is forwarded literally to the backend.
+        Example: /api/proxy/deployment/v1/embeddings -> /v1/embeddings
+        """
+        dep = _get_running_deployment(deployment, manager)
+        backend_url = _backend_url(dep, config)
+        body = await request.json()
+
+        return _blocking_proxy(backend_url + f"/{path}", body)
+
+    # ── /v1/ OpenAI-compatible inference routes ────────────────────
 
     @app.get("/v1/models")
     async def list_models() -> dict[str, Any]:
@@ -275,20 +343,17 @@ def _register_routes(app: FastAPI) -> None:
             backend_url + "/v1/chat/completions", backend_body
         )
 
-    @app.post("/v1/backends/{deployment}/{path:path}")
-    async def backend_passthrough(
-        request: Request, deployment: str, path: str,
-    ) -> Any:
-        """Scoped passthrough to backend-specific endpoints.
 
-        Routes to backend container for deployment-specific API calls
-        (embeddings, tool calls, etc.).
-        """
-        dep = _get_running_deployment(deployment, manager)
-        backend_url = _backend_url(dep, config)
-        body = await request.json()
-
-        return _blocking_proxy(backend_url + f"/v1/{path}", body)
+def _mask_sensitive_args(args: dict[str, Any]) -> dict[str, Any]:
+    """Mask sensitive runtime args (tokens, keys, secrets) in the detail response."""
+    sensitive_keys = {"hf_token", "api_key", "secret_key", "password", "token"}
+    masked: dict[str, Any] = {}
+    for key, value in args.items():
+        if key in sensitive_keys and value is not None:
+            masked[key] = "***redacted***"
+        else:
+            masked[key] = value
+    return masked
 
 
 def _get_running_deployment(

--- a/switchyard-api/src/switchyard/app.py
+++ b/switchyard-api/src/switchyard/app.py
@@ -210,11 +210,13 @@ def _register_routes(app: FastAPI) -> None:
                 "port": info.port,
                 "container_id": info.container_id,
                 "started_at": info.started_at.isoformat(),
+                "health": "unknown",
             }
         except KeyError:
             return {
                 "deployment_name": deployment,
                 "status": "stopped",
+                "health": "unknown",
             }
 
     @app.post("/api/deployments/{deployment}/load", status_code=202)

--- a/switchyard-api/src/switchyard/app.py
+++ b/switchyard-api/src/switchyard/app.py
@@ -145,9 +145,19 @@ def _register_routes(app: FastAPI) -> None:
 
     @app.get("/api/deployments")
     async def list_deployments() -> list[dict[str, Any]]:
-        """List all configured deployments with current status."""
+        """List all configured deployments with current status.
+
+        Reconciles each deployment with Docker before reporting status:
+        adopts running containers, clears stale in-memory state.
+        """
         results: list[dict[str, Any]] = []
         for dep_name, dep_cfg in config.deployments.items():
+            try:
+                resolved = resolve_deployment(config, dep_name)
+                manager.reconcile(dep_name, resolved)
+            except Exception:
+                pass  # Docker unreachable or config broken
+
             try:
                 info = manager.state.get(dep_name)
                 status = info.status
@@ -164,13 +174,25 @@ def _register_routes(app: FastAPI) -> None:
 
     @app.get("/api/deployments/{deployment}")
     async def get_deployment(deployment: str) -> dict[str, Any]:
-        """Get deployment detail: configured intent + small status summary."""
+        """Get deployment detail: configured intent + small status summary.
+
+        Reconciles with Docker before reporting to adopt running containers
+        or clear stale state.
+        """
         if deployment not in config.deployments:
             raise HTTPException(
                 status_code=404,
                 detail=f"deployment {deployment!r} not found in config",
             )
         dep_cfg = config.deployments[deployment]
+
+        # Reconcile before reporting
+        try:
+            resolved = resolve_deployment(config, deployment)
+            manager.reconcile(deployment, resolved)
+        except Exception:
+            pass  # Docker unreachable
+
         try:
             info = manager.state.get(deployment)
             status = info.status
@@ -205,11 +227,10 @@ def _register_routes(app: FastAPI) -> None:
                 detail=f"deployment {deployment!r} not found in config",
             )
 
-        # Reconcile: adopt any running container after API restart
-        # (don't clear existing state — that's load_model's job)
+        # Reconcile: adopt running containers, clear stale state
         try:
             resolved = resolve_deployment(config, deployment)
-            manager.reconcile(deployment, resolved, adopt_only=True)
+            manager.reconcile(deployment, resolved)
         except Exception:
             pass  # Docker unreachable or config broken
 
@@ -301,11 +322,11 @@ def _register_routes(app: FastAPI) -> None:
         The path is forwarded literally to the backend.
         Example: /api/proxy/deployment/v1/embeddings -> /v1/embeddings
         """
-        # Reconcile to adopt running containers after API restart
+        # Reconcile to adopt running containers, clear stale state
         if deployment in config.deployments:
             try:
                 resolved = resolve_deployment(config, deployment)
-                manager.reconcile(deployment, resolved, adopt_only=True)
+                manager.reconcile(deployment, resolved)
             except Exception:
                 pass  # Docker unreachable
 
@@ -324,14 +345,14 @@ def _register_routes(app: FastAPI) -> None:
         Returns active (running) deployments as a list of OpenAI-compatible
         model objects. Only deployments with status "running" are included.
 
-        Adopts any running containers after API restart without clearing
-        existing in-memory state.
+        Reconciles each configured deployment with Docker to adopt running
+        containers and clear stale state.
         """
-        # Adopt any running containers after API restart
+        # Reconcile all configured deployments
         for dep_name in config.deployments:
             try:
                 resolved = resolve_deployment(config, dep_name)
-                manager.reconcile(dep_name, resolved, adopt_only=True)
+                manager.reconcile(dep_name, resolved)
             except Exception:
                 pass  # Docker unreachable or config broken
 
@@ -359,11 +380,11 @@ def _register_routes(app: FastAPI) -> None:
         body = await request.json()
         deployment_name = body.get("model", "")
 
-        # Reconcile to adopt running containers after API restart
+        # Reconcile to adopt running containers, clear stale state
         if deployment_name in config.deployments:
             try:
                 resolved = resolve_deployment(config, deployment_name)
-                manager.reconcile(deployment_name, resolved, adopt_only=True)
+                manager.reconcile(deployment_name, resolved)
             except Exception:
                 pass  # Docker unreachable
 

--- a/switchyard-api/src/switchyard/app.py
+++ b/switchyard-api/src/switchyard/app.py
@@ -107,6 +107,7 @@ def create_app(config_overrides: dict[str, Any] | None = None) -> FastAPI:
     app.state.config = config
 
     # Create lifecycle manager with port range from active host
+    from switchyard.core.docker import create_default_factory
     from switchyard.core.registry import AdapterRegistry
 
     registry = AdapterRegistry()
@@ -120,6 +121,7 @@ def create_app(config_overrides: dict[str, Any] | None = None) -> FastAPI:
         backend_host=backend_host,
         backend_scheme=backend_scheme,
         docker_network=docker_network,
+        docker_client_factory=create_default_factory(),
     )
 
     # Register endpoints
@@ -202,6 +204,15 @@ def _register_routes(app: FastAPI) -> None:
                 status_code=404,
                 detail=f"deployment {deployment!r} not found in config",
             )
+
+        # Reconcile: adopt any running container after API restart
+        # (don't clear existing state — that's load_model's job)
+        try:
+            resolved = resolve_deployment(config, deployment)
+            manager.reconcile(deployment, resolved, adopt_only=True)
+        except Exception:
+            pass  # Docker unreachable or config broken
+
         try:
             info = manager.state.get(deployment)
             return {
@@ -254,12 +265,25 @@ def _register_routes(app: FastAPI) -> None:
 
     @app.post("/api/deployments/{deployment}/unload")
     async def unload_deployment(deployment: str) -> dict[str, str]:
-        """Unload a deployment."""
+        """Unload a deployment.
+
+        Reconciles with Docker first so that stopped running containers
+        after API restart are properly stopped rather than silently ignored.
+        """
         if deployment not in config.deployments:
             raise HTTPException(
                 status_code=404,
                 detail=f"deployment {deployment!r} not found in config",
             )
+
+        # Reconcile first: if a running container exists after API restart,
+        # adopt it into state so it can be stopped
+        try:
+            resolved = resolve_deployment(config, deployment)
+            manager.reconcile(deployment, resolved)
+        except Exception:
+            pass  # Docker unreachable
+
         try:
             await manager.unload_model(deployment)
         except KeyError:
@@ -277,6 +301,14 @@ def _register_routes(app: FastAPI) -> None:
         The path is forwarded literally to the backend.
         Example: /api/proxy/deployment/v1/embeddings -> /v1/embeddings
         """
+        # Reconcile to adopt running containers after API restart
+        if deployment in config.deployments:
+            try:
+                resolved = resolve_deployment(config, deployment)
+                manager.reconcile(deployment, resolved, adopt_only=True)
+            except Exception:
+                pass  # Docker unreachable
+
         dep = _get_running_deployment(deployment, manager)
         backend_url = _backend_url(dep, config)
         body = await request.json()
@@ -291,7 +323,18 @@ def _register_routes(app: FastAPI) -> None:
 
         Returns active (running) deployments as a list of OpenAI-compatible
         model objects. Only deployments with status "running" are included.
+
+        Adopts any running containers after API restart without clearing
+        existing in-memory state.
         """
+        # Adopt any running containers after API restart
+        for dep_name in config.deployments:
+            try:
+                resolved = resolve_deployment(config, dep_name)
+                manager.reconcile(dep_name, resolved, adopt_only=True)
+            except Exception:
+                pass  # Docker unreachable or config broken
+
         deployments = manager.state.list_deployments()
         models = [
             {
@@ -315,6 +358,15 @@ def _register_routes(app: FastAPI) -> None:
         """
         body = await request.json()
         deployment_name = body.get("model", "")
+
+        # Reconcile to adopt running containers after API restart
+        if deployment_name in config.deployments:
+            try:
+                resolved = resolve_deployment(config, deployment_name)
+                manager.reconcile(deployment_name, resolved, adopt_only=True)
+            except Exception:
+                pass  # Docker unreachable
+
         deployment = _get_running_deployment(deployment_name, manager)
         backend_url = _backend_url(deployment, config)
         backend_body = dict(body)

--- a/switchyard-api/src/switchyard/core/docker.py
+++ b/switchyard-api/src/switchyard/core/docker.py
@@ -120,3 +120,14 @@ def get_container_host_port(
     if bindings:
         return int(bindings[0]["HostPort"])
     return None
+
+
+def remove_container(container: _DockerContainer) -> None:
+    """Force-remove a Docker container.
+
+    Used to clean up stale exited/dead managed containers.
+
+    Args:
+        container: The Docker container to remove.
+    """
+    container.remove(force=True)

--- a/switchyard-api/src/switchyard/core/docker.py
+++ b/switchyard-api/src/switchyard/core/docker.py
@@ -1,28 +1,122 @@
 """Docker client factory for Switchyard.
 
 Centralizes Docker SDK client creation so that local and remote Docker
-configurations are explicit and testable.
+configurations are explicit and testable. Provides a host-aware factory
+for multi-host reconciliation.
 """
 
 from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Protocol, cast
 
 import docker
 
 from switchyard.config.models import AppSettings
 
+DockerClientFactory = Callable[[str | None], docker.DockerClient]
 
-def get_docker_client() -> docker.DockerClient:
-    """Create a Docker SDK client respecting environment configuration.
 
-    Uses ``SWITCHYARD_DOCKER_HOST`` (via pydantic-settings ``AppSettings``)
-    as ``base_url`` when set. Otherwise falls back to ``docker.from_env()``,
-    which respects the native ``DOCKER_HOST`` and ``DOCKER_TLS_VERIFY``
-    environment variables.
+class _DockerContainer(Protocol):
+    """Minimal Docker container interface for reconciliation."""
+
+    @property
+    def labels(self) -> dict[str, Any]: ...
+
+    @property
+    def short_id(self) -> str: ...
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def attrs(self) -> dict[str, Any]: ...
+
+    def remove(self, *, force: bool) -> None: ...
+
+
+def get_docker_client(docker_host: str | None = None) -> docker.DockerClient:
+    """Create a Docker SDK client for the given host.
+
+    Args:
+        docker_host: Optional host-specific Docker daemon address.
+            If set, used as ``base_url``. Otherwise falls back to
+            ``SWITCHYARD_DOCKER_HOST`` from ``AppSettings``, then to
+            ``docker.from_env()``.
 
     Returns:
         A configured ``docker.DockerClient`` instance.
     """
+    if docker_host is not None:
+        return docker.DockerClient(base_url=docker_host)
     settings = AppSettings()
     if settings.docker_host is not None:
         return docker.DockerClient(base_url=settings.docker_host)
     return docker.from_env()
+
+
+def create_default_factory() -> DockerClientFactory:
+    """Create the default host-aware Docker client factory.
+
+    Returns a callable that produces a ``docker.DockerClient`` for the
+    given ``docker_host`` hint.
+    """
+    return get_docker_client
+
+
+def find_container_by_labels(
+    client: docker.DockerClient,
+    deployment_name: str,
+) -> _DockerContainer | None:
+    """Find a Switchyard-managed container by deployment label.
+
+    Looks for a container labelled with ``switchyard.managed=true`` and
+    ``switchyard.deployment={deployment_name}``.
+
+    Args:
+        client: Docker SDK client.
+        deployment_name: The deployment logical name.
+
+    Returns:
+        The container if found, ``None`` otherwise.
+    """
+    filters: dict[str, list[str]] = {
+        "label": [
+            "switchyard.managed=true",
+            f"switchyard.deployment={deployment_name}",
+        ],
+    }
+    containers = client.containers.list(all=True, filters=filters)  # type: ignore[arg-type]
+    if not containers:
+        return None
+    return cast(_DockerContainer, containers[0])
+
+
+def get_container_status(container: _DockerContainer) -> str:
+    """Extract the normalized Docker container status.
+
+    Returns one of: ``running``, ``exited``, ``dead``, ``created``,
+    ``paused``, ``restarting``.
+    """
+    attrs = container.attrs
+    return cast(str, attrs["State"]["Status"])
+
+
+def get_container_host_port(
+    container: _DockerContainer, internal_port: int,
+) -> int | None:
+    """Extract the host port bound to a given internal port.
+
+    Args:
+        container: The Docker container.
+        internal_port: The container's internal port (e.g. 8000).
+
+    Returns:
+        The host port if bound, ``None`` otherwise.
+    """
+    ports = container.attrs["NetworkSettings"]["Ports"]
+    port_key = f"{internal_port}/tcp"
+    bindings = ports.get(port_key)
+    if bindings:
+        return int(bindings[0]["HostPort"])
+    return None

--- a/switchyard-api/src/switchyard/core/lifecycle.py
+++ b/switchyard-api/src/switchyard/core/lifecycle.py
@@ -8,16 +8,28 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import TYPE_CHECKING
+
+import docker
 
 from switchyard.config.models import (
     Config,
     ResolvedDeployment,
 )
 from switchyard.core.adapter import BackendAdapter, DeploymentInfo
+from switchyard.core.docker import DockerClientFactory as DockerClientFactoryType
+from switchyard.core.docker import (
+    find_container_by_labels,
+    get_container_host_port,
+    get_container_status,
+)
 from switchyard.core.orphan import OrphanDetector, _DockerClient
 from switchyard.core.ports import PortAllocator
 from switchyard.core.registry import AdapterRegistry
 from switchyard.core.state import DeploymentStateManager
+
+if TYPE_CHECKING:
+    from switchyard.core.docker import _DockerContainer
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +54,7 @@ class LifecycleManager:
         backend_host: str = "localhost",
         backend_scheme: str = "http",
         docker_network: str | None = None,
+        docker_client_factory: DockerClientFactoryType | None = None,
     ) -> None:
         self.registry = registry or AdapterRegistry()
         self.port_allocator = port_allocator or PortAllocator()
@@ -51,6 +64,7 @@ class LifecycleManager:
         self._backend_host = backend_host
         self._backend_scheme = backend_scheme
         self._docker_network = docker_network
+        self._docker_client_factory = docker_client_factory
         # backend name → live adapter instance (one per backend, reused)
         self._adapters: dict[str, BackendAdapter] = {}
         # model name → background health task
@@ -67,6 +81,168 @@ class LifecycleManager:
             )
         return self._adapters[backend]
 
+    def reconcile(
+        self, deployment_name: str, resolved: ResolvedDeployment,
+    ) -> DeploymentInfo | None:
+        """Reconcile in-memory state with actual Docker container state.
+
+        Looks up the Docker container by Switchyard labels and corrects
+        in-memory state to match reality.
+
+        Four outcomes:
+        1. Container running and already in memory → preserve state, update
+           to running if needed, return DeploymentInfo.
+        2. Container running and missing from memory → adopt it, reserve
+           port, return DeploymentInfo.
+        3. Container exited/dead → clear in-memory state, release port,
+           cancel health task, return None.
+        4. Container gone → clear in-memory state, release port, cancel
+           health task, return None.
+
+        Args:
+            deployment_name: Logical deployment identifier.
+            resolved: Fully resolved deployment configuration.
+
+        Returns:
+            ``DeploymentInfo`` if the deployment is running, ``None``
+            otherwise.
+        """
+        # No factory configured → skip reconciliation
+        if self._docker_client_factory is None:
+            # If we have in-memory state, return it as-is
+            try:
+                return self.state.get(deployment_name)
+            except KeyError:
+                return None
+
+        client = self._docker_client_factory(resolved.docker_host)
+        container = self._find_container(client, deployment_name)
+
+        if container is None:
+            # Container gone → clear any stale state
+            self._clear_deployment(deployment_name)
+            return None
+
+        status = self._get_container_status(container)
+
+        if status == "running":
+            return self._handle_running(deployment_name, container, resolved)
+
+        # exited, dead, or other non-running state
+        self._clear_deployment(deployment_name)
+        return None
+
+    def _find_container(
+        self, client: docker.DockerClient, deployment_name: str,
+    ) -> _DockerContainer | None:
+        """Find a Switchyard-managed container by label."""
+        return find_container_by_labels(client, deployment_name)
+
+    def _get_container_status(self, container: _DockerContainer) -> str:
+        """Get normalized Docker container status."""
+        return get_container_status(container)
+
+    def _handle_running(
+        self,
+        deployment_name: str,
+        container: _DockerContainer,
+        resolved: ResolvedDeployment,
+    ) -> DeploymentInfo:
+        """Handle a running container found during reconciliation."""
+        existing = self.state._deployments.get(deployment_name)
+
+        if existing is not None:
+            # Already in memory — ensure status is running
+            if existing.status != "running":
+                self.state.update_status(deployment_name, "running")
+            return self.state.get(deployment_name)
+
+        # Running container not in memory → adopt it
+        internal_port = resolved.internal_port
+        port = get_container_host_port(container, internal_port)
+        if port is None:
+            # Can't determine port — treat as gone
+            return self._adopt_container(deployment_name, container, resolved)
+
+        # Reserve the observed port
+        try:
+            self.port_allocator.allocate(port=port)
+        except ValueError:
+            pass  # already allocated
+
+        info = DeploymentInfo(
+            model_name=deployment_name,
+            backend=resolved.backend,
+            port=port,
+            status="running",
+            container_id=container.short_id,
+            metadata=dict(resolved.runtime_args),
+        )
+        self.state.add(info)
+        logger.info(
+            "reconcile: adopted running container for %s "
+            "(port=%d container=%s)",
+            deployment_name, port, container.short_id,
+        )
+        return info
+
+    def _adopt_container(
+        self,
+        deployment_name: str,
+        container: _DockerContainer,
+        resolved: ResolvedDeployment,
+    ) -> DeploymentInfo:
+        """Adopt a running container even when host port can't be resolved."""
+        info = DeploymentInfo(
+            model_name=deployment_name,
+            backend=resolved.backend,
+            port=resolved.internal_port,
+            status="running",
+            container_id=container.short_id,
+            metadata=dict(resolved.runtime_args),
+        )
+        self.state.add(info)
+        return info
+
+    def _clear_deployment(self, deployment_name: str) -> None:
+        """Clear in-memory state, release port, cancel health task."""
+        # Cancel health task
+        if deployment_name in self._health_tasks:
+            self._health_tasks[deployment_name].cancel()
+            try:
+                loop = asyncio.get_event_loop()
+                if loop.is_running():
+                    loop.create_task(self._wait_for_cancellation(
+                        self._health_tasks[deployment_name],
+                    ))
+                else:
+                    # Synchronous context — just discard
+                        pass
+            except Exception:
+                pass
+            del self._health_tasks[deployment_name]
+
+        # Remove state and release port
+        try:
+            info = self.state.get(deployment_name)
+            self.port_allocator.release(info.port)
+            self.state.remove(deployment_name)
+            logger.info(
+                "reconcile: cleared stale state for %s (port=%d released)",
+                deployment_name, info.port,
+            )
+        except KeyError:
+            pass  # already gone from state
+
+    async def _wait_for_cancellation(self, task: asyncio.Task[None]) -> None:
+        """Wait for a cancelled task to finish."""
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            pass
+
     async def load_model(
         self, deployment_name: str, resolved: ResolvedDeployment,
     ) -> DeploymentInfo:
@@ -75,6 +251,9 @@ class LifecycleManager:
         Allocates a port, starts the container via the backend adapter,
         records the deployment in state as ``"loading"``, and begins
         background health polling.
+
+        Before starting, reconciles in-memory state with Docker to clear
+        stale state or adopt an already-running container.
 
         Returns immediately (non-blocking).
 
@@ -89,7 +268,18 @@ class LifecycleManager:
             ValueError: If the deployment is already loaded.
             KeyError: If the backend is not registered.
         """
-        # Check for duplicates
+        # Reconcile first: clear stale state or adopt running container
+        # Only block on "already running" if we actually found a Docker container
+        reconciled = self.reconcile(deployment_name, resolved)
+        if reconciled is not None and self._docker_client_factory is not None:
+            # Container already running (adopted or preserved)
+            raise ValueError(
+                f"deployment {deployment_name!r} is already running "
+                f"(container {reconciled.container_id})"
+            )
+
+        # Check for duplicates in state (should be cleared by reconcile,
+        # but defensive check remains)
         if deployment_name in self.state.list_deployments():
             existing = self.state.get(deployment_name)
             raise ValueError(
@@ -148,13 +338,25 @@ class LifecycleManager:
         Stops the container via the adapter, releases the port,
         cancels the background health task, and removes state.
 
+        If the container is already gone (cleared by reconcile),
+        returns idempotent success.
+
         Args:
             deployment_name: The deployment to unload.
 
         Raises:
             KeyError: If the deployment is not found in state.
         """
-        deployment = self.state.get(deployment_name)
+        # Check if deployment exists in state
+        try:
+            deployment = self.state.get(deployment_name)
+        except KeyError:
+            # Not in state — check Docker for any straggler
+            # Cancel health task if it exists
+            if deployment_name in self._health_tasks:
+                self._health_tasks[deployment_name].cancel()
+                del self._health_tasks[deployment_name]
+            return  # idempotent: already unloaded
 
         # Cancel health poll
         if deployment_name in self._health_tasks:

--- a/switchyard-api/src/switchyard/core/lifecycle.py
+++ b/switchyard-api/src/switchyard/core/lifecycle.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import docker
 
@@ -22,11 +22,15 @@ from switchyard.core.docker import (
     find_container_by_labels,
     get_container_host_port,
     get_container_status,
+    remove_container,
 )
 from switchyard.core.orphan import OrphanDetector, _DockerClient
 from switchyard.core.ports import PortAllocator
 from switchyard.core.registry import AdapterRegistry
 from switchyard.core.state import DeploymentStateManager
+
+if TYPE_CHECKING:
+    from switchyard.core.docker import _DockerContainer
 
 if TYPE_CHECKING:
     from switchyard.core.docker import _DockerContainer
@@ -83,6 +87,7 @@ class LifecycleManager:
 
     def reconcile(
         self, deployment_name: str, resolved: ResolvedDeployment,
+        *, adopt_only: bool = False,
     ) -> DeploymentInfo | None:
         """Reconcile in-memory state with actual Docker container state.
 
@@ -99,9 +104,15 @@ class LifecycleManager:
         4. Container gone → clear in-memory state, release port, cancel
            health task, return None.
 
+        If ``adopt_only=True``, only outcome 1 and 2 apply — existing
+        in-memory state is never cleared. This is suitable for routes
+        that just need to adopt a running container after API restart.
+
         Args:
             deployment_name: Logical deployment identifier.
             resolved: Fully resolved deployment configuration.
+            adopt_only: If True, only adopt running containers; never
+                clear existing in-memory state.
 
         Returns:
             ``DeploymentInfo`` if the deployment is running, ``None``
@@ -119,8 +130,9 @@ class LifecycleManager:
         container = self._find_container(client, deployment_name)
 
         if container is None:
-            # Container gone → clear any stale state
-            self._clear_deployment(deployment_name)
+            # Container gone → clear any stale state (unless adopt_only)
+            if not adopt_only:
+                self._clear_deployment(deployment_name)
             return None
 
         status = self._get_container_status(container)
@@ -128,8 +140,10 @@ class LifecycleManager:
         if status == "running":
             return self._handle_running(deployment_name, container, resolved)
 
-        # exited, dead, or other non-running state
-        self._clear_deployment(deployment_name)
+        # exited, dead, or other non-running state → clear + remove
+        if not adopt_only:
+            remove_container(container)
+            self._clear_deployment(deployment_name)
         return None
 
     def _find_container(
@@ -147,7 +161,7 @@ class LifecycleManager:
         deployment_name: str,
         container: _DockerContainer,
         resolved: ResolvedDeployment,
-    ) -> DeploymentInfo:
+    ) -> DeploymentInfo | None:
         """Handle a running container found during reconciliation."""
         existing = self.state._deployments.get(deployment_name)
 
@@ -161,8 +175,14 @@ class LifecycleManager:
         internal_port = resolved.internal_port
         port = get_container_host_port(container, internal_port)
         if port is None:
-            # Can't determine port — treat as gone
-            return self._adopt_container(deployment_name, container, resolved)
+            # Can't determine host port — can't safely adopt.
+            # Container is running but we can't route to it.
+            logger.warning(
+                "reconcile: running container for %s has no bound host "
+                "port (internal=%d) — skipping adoption",
+                deployment_name, internal_port,
+            )
+            return None
 
         # Reserve the observed port
         try:
@@ -176,7 +196,7 @@ class LifecycleManager:
             port=port,
             status="running",
             container_id=container.short_id,
-            metadata=dict(resolved.runtime_args),
+            metadata=self._build_adopted_metadata(resolved),
         )
         self.state.add(info)
         logger.info(
@@ -186,23 +206,22 @@ class LifecycleManager:
         )
         return info
 
-    def _adopt_container(
-        self,
-        deployment_name: str,
-        container: _DockerContainer,
-        resolved: ResolvedDeployment,
-    ) -> DeploymentInfo:
-        """Adopt a running container even when host port can't be resolved."""
-        info = DeploymentInfo(
-            model_name=deployment_name,
-            backend=resolved.backend,
-            port=resolved.internal_port,
-            status="running",
-            container_id=container.short_id,
-            metadata=dict(resolved.runtime_args),
-        )
-        self.state.add(info)
-        return info
+    def _build_adopted_metadata(
+        self, resolved: ResolvedDeployment,
+    ) -> dict[str, Any]:
+        """Build metadata dict for an adopted deployment.
+
+        Includes the fields needed by _backend_url() and
+        chat_completions model rewriting.
+        """
+        metadata: dict[str, Any] = dict(resolved.runtime_args)
+        metadata["backend_host"] = resolved.backend_host
+        metadata["backend_scheme"] = resolved.backend_scheme
+        if resolved.model_defaults and "served_model_name" in resolved.model_defaults:
+            metadata["served_model_name"] = resolved.model_defaults[
+                "served_model_name"
+            ]
+        return metadata
 
     def _clear_deployment(self, deployment_name: str) -> None:
         """Clear in-memory state, release port, cancel health task."""

--- a/switchyard-api/src/switchyard/core/lifecycle.py
+++ b/switchyard-api/src/switchyard/core/lifecycle.py
@@ -32,9 +32,6 @@ from switchyard.core.state import DeploymentStateManager
 if TYPE_CHECKING:
     from switchyard.core.docker import _DockerContainer
 
-if TYPE_CHECKING:
-    from switchyard.core.docker import _DockerContainer
-
 logger = logging.getLogger(__name__)
 
 _DEFAULT_HEALTH_INTERVAL = 2.0  # seconds between health polls
@@ -87,7 +84,6 @@ class LifecycleManager:
 
     def reconcile(
         self, deployment_name: str, resolved: ResolvedDeployment,
-        *, adopt_only: bool = False,
     ) -> DeploymentInfo | None:
         """Reconcile in-memory state with actual Docker container state.
 
@@ -100,19 +96,13 @@ class LifecycleManager:
         2. Container running and missing from memory → adopt it, reserve
            port, return DeploymentInfo.
         3. Container exited/dead → clear in-memory state, release port,
-           cancel health task, return None.
+           cancel health task, remove container, return None.
         4. Container gone → clear in-memory state, release port, cancel
            health task, return None.
-
-        If ``adopt_only=True``, only outcome 1 and 2 apply — existing
-        in-memory state is never cleared. This is suitable for routes
-        that just need to adopt a running container after API restart.
 
         Args:
             deployment_name: Logical deployment identifier.
             resolved: Fully resolved deployment configuration.
-            adopt_only: If True, only adopt running containers; never
-                clear existing in-memory state.
 
         Returns:
             ``DeploymentInfo`` if the deployment is running, ``None``
@@ -130,9 +120,8 @@ class LifecycleManager:
         container = self._find_container(client, deployment_name)
 
         if container is None:
-            # Container gone → clear any stale state (unless adopt_only)
-            if not adopt_only:
-                self._clear_deployment(deployment_name)
+            # Container gone → clear any stale state
+            self._clear_deployment(deployment_name)
             return None
 
         status = self._get_container_status(container)
@@ -141,9 +130,8 @@ class LifecycleManager:
             return self._handle_running(deployment_name, container, resolved)
 
         # exited, dead, or other non-running state → clear + remove
-        if not adopt_only:
-            remove_container(container)
-            self._clear_deployment(deployment_name)
+        remove_container(container)
+        self._clear_deployment(deployment_name)
         return None
 
     def _find_container(
@@ -213,14 +201,16 @@ class LifecycleManager:
 
         Includes the fields needed by _backend_url() and
         chat_completions model rewriting.
+
+        ``served_model_name`` comes from ``resolved.runtime_args`` (which
+        already has deployment/runtime overrides applied), not from
+        ``resolved.model_defaults``.
         """
         metadata: dict[str, Any] = dict(resolved.runtime_args)
         metadata["backend_host"] = resolved.backend_host
         metadata["backend_scheme"] = resolved.backend_scheme
-        if resolved.model_defaults and "served_model_name" in resolved.model_defaults:
-            metadata["served_model_name"] = resolved.model_defaults[
-                "served_model_name"
-            ]
+        # served_model_name from runtime_args is authoritative; overrides
+        # take precedence over raw model_defaults
         return metadata
 
     def _clear_deployment(self, deployment_name: str) -> None:

--- a/switchyard-api/tests/conftest.py
+++ b/switchyard-api/tests/conftest.py
@@ -40,5 +40,7 @@ def _isolate_app_settings(request: pytest.FixtureRequest) -> None:
         "switchyard.config.models.AppSettings", return_value=mock,
     ), patch(
         "switchyard.config.loader.AppSettings", return_value=mock,
+    ), patch(
+        "switchyard.core.docker.AppSettings", return_value=mock,
     ):
         yield

--- a/switchyard-api/tests/test_api.py
+++ b/switchyard-api/tests/test_api.py
@@ -2,10 +2,11 @@
 
 Validates:
 - GET /health returns 200
-- POST /deployments/load starts a deployment
-- POST /deployments/unload stops a deployment
-- GET /deployments lists deployments from state
-- GET /deployments/{name}/status returns deployment status
+- POST /api/deployments/{deployment}/load starts a deployment
+- POST /api/deployments/{deployment}/unload stops a deployment
+- GET /api/deployments lists deployments from config + state
+- GET /api/deployments/{deployment}/status returns deployment status
+- GET /api/deployments/{deployment} returns deployment detail
 - OpenAI-compatible passthrough routes are preserved
 """
 
@@ -75,18 +76,22 @@ class TestHealth:
         assert response.status_code == 200
 
 
-class TestDeploymentRoutes:
-    """Route tests for /deployments endpoints (T4.10)."""
+class TestApiDeploymentRoutes:
+    """Route tests for new /api/deployments endpoints (T1.1-T1.6)."""
 
-    def test_list_deployments(self) -> None:
-        """Empty state returns empty list."""
+    def test_list_deployments_returns_all_configured(self) -> None:
+        """GET /api/deployments returns all configured deployments with status."""
         app = create_app()
-        response = TestClient(app).get("/deployments")
+        response = TestClient(app).get("/api/deployments")
         assert response.status_code == 200
-        assert response.json() == []
+        data = response.json()
+        # Should return all configured deployments, even with no lifecycle state
+        assert len(data) == 1
+        assert data[0]["deployment_name"] == "test-deployment"
+        assert data[0]["status"] == "stopped"
 
-    def test_list_deployments_with_entries(self) -> None:
-        """State entries appear in deployment list."""
+    def test_list_deployments_includes_active_status(self) -> None:
+        """Active deployments reflect their actual in-memory status."""
         from switchyard.core.adapter import DeploymentInfo
 
         app = create_app()
@@ -99,37 +104,111 @@ class TestDeploymentRoutes:
         )
         app.state.manager.state.add(info)
 
-        response = TestClient(app).get("/deployments")
+        response = TestClient(app).get("/api/deployments")
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 1
         assert data[0]["deployment_name"] == "test-deployment"
+        assert data[0]["status"] == "running"
 
-    def test_load_deployment_unknown(self) -> None:
-        """Loading an unknown deployment raises 404."""
+    def test_detail_returns_config_and_status(self) -> None:
+        """GET /api/deployments/{deployment} returns config detail + status summary."""
         app = create_app()
-        response = TestClient(app).post(
-            "/deployments/load",
-            json={"deployment": "nonexistent"},
-        )
+        response = TestClient(app).get("/api/deployments/test-deployment")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deployment_name"] == "test-deployment"
+        assert data["model"] == "test-model"
+        assert data["runtime"] == "vllm"
+        assert data["host"] == "test-host"
+        assert data["status"] == "stopped"
+
+    def test_detail_unknown_returns_404(self) -> None:
+        """GET /api/deployments/{deployment} returns 404 for unknown deployment."""
+        app = create_app()
+        response = TestClient(app).get("/api/deployments/nonexistent")
         assert response.status_code == 404
 
-    def test_load_deployment_success(self) -> None:
-        """Loading a known deployment calls resolve_deployment + load_model."""
+    def test_detail_masks_sensitive_runtime_args(self) -> None:
+        """Sensitive runtime args like hf_token are masked in detail response."""
+        from switchyard.config.models import Config
+
+        config = Config.model_validate({
+            "hosts": {
+                "test-host": {
+                    "stores": {
+                        "models": {
+                            "host_path": "/data/models",
+                            "container_path": "/models",
+                        },
+                    },
+                    "port_range": [9000, 9100],
+                },
+            },
+            "runtimes": {"vllm": {"backend": "vllm"}},
+            "models": {
+                "test-model": {
+                    "source": {"store": "models", "path": "test-model"},
+                    "defaults": {"hf_token": "secret-token-123"},
+                },
+            },
+            "deployments": {
+                "test-deployment": {
+                    "model": "test-model",
+                    "runtime": "vllm",
+                    "host": "test-host",
+                },
+            },
+        })
+        with patch("switchyard.app.ConfigLoader.load", return_value=config):
+            app = create_app()
+        response = TestClient(app).get("/api/deployments/test-deployment")
+        assert response.status_code == 200
+        data = response.json()
+        args = data["runtime_args"]
+        # hf_token should be masked, not exposed
+        assert args.get("hf_token") == "***redacted***"
+
+    def test_status_known(self) -> None:
+        """GET /api/deployments/{deployment}/status returns status (known)."""
+        from switchyard.core.adapter import DeploymentInfo
+
         app = create_app()
-
-        response = TestClient(app).post(
-            "/deployments/load",
-            json={"deployment": "test-deployment"},
+        info = DeploymentInfo(
+            model_name="test-deployment",
+            backend="vllm",
+            port=9001,
+            status="running",
+            container_id="abc123",
         )
+        app.state.manager.state.add(info)
 
+        response = TestClient(app).get("/api/deployments/test-deployment/status")
+        assert response.status_code == 200
+        assert response.json()["status"] == "running"
+
+    def test_status_unknown_returns_404(self) -> None:
+        """GET /api/deployments/{deployment}/status returns 404 (unknown)."""
+        app = create_app()
+        response = TestClient(app).get("/api/deployments/nonexistent/status")
+        assert response.status_code == 404
+
+    def test_load_by_path_returns_202(self) -> None:
+        """POST /api/deployments/{deployment}/load loads by path ID, returns 202."""
+        app = create_app()
+        response = TestClient(app).post("/api/deployments/test-deployment/load")
         assert response.status_code == 202
-        # Verify the manager's state was updated
         info = app.state.manager.state.get("test-deployment")
         assert info.status in ("loading", "running")
 
-    def test_load_deployment_start_failure_returns_500(self) -> None:
-        """T5.2: adapter.start() RuntimeError returns structured 500 JSON."""
+    def test_load_unknown_returns_404(self) -> None:
+        """POST /api/deployments/{deployment}/load returns 404 (unknown)."""
+        app = create_app()
+        response = TestClient(app).post("/api/deployments/nonexistent/load")
+        assert response.status_code == 404
+
+    def test_load_runtime_error_returns_structured_500(self) -> None:
+        """RuntimeError from adapter.start() returns structured 500 JSON."""
         from switchyard.core.adapter import BackendAdapter
 
         class FailingAdapter(BackendAdapter):
@@ -155,8 +234,7 @@ class TestDeploymentRoutes:
         registry.register("vllm", FailingAdapter)
 
         response = TestClient(app, raise_server_exceptions=False).post(
-            "/deployments/load",
-            json={"deployment": "test-deployment"},
+            "/api/deployments/test-deployment/load",
         )
 
         assert response.status_code == 500
@@ -167,13 +245,8 @@ class TestDeploymentRoutes:
         with pytest.raises(KeyError):
             app.state.manager.state.get("test-deployment")
 
-    def test_load_deployment_non_runtime_error_surfaces(self) -> None:
-        """T5.2 boundary: non-RuntimeError exceptions are not the structured 500.
-
-        Programming mistakes, config errors, and unrelated bugs should surface
-        as real server errors, not as the structured 'failed to start deployment'
-        response.
-        """
+    def test_load_non_runtime_error_surfaces(self) -> None:
+        """Non-RuntimeError exceptions surface as real server errors."""
         from switchyard.core.adapter import BackendAdapter
 
         class BugAdapter(BackendAdapter):
@@ -183,7 +256,7 @@ class TestDeploymentRoutes:
             def start(
                 self, resolved, port: int,  # noqa: ANN001
             ):
-                raise TypeError("internal bug")  # not a RuntimeError
+                raise TypeError("internal bug")
 
             def stop(self, deployment) -> None:  # noqa: ANN001
                 pass
@@ -198,57 +271,16 @@ class TestDeploymentRoutes:
         registry = app.state.manager.registry
         registry.register("vllm", BugAdapter)
 
-        # TypeError is not RuntimeError, so the route does NOT convert it
-        # to the structured 500 "failed to start deployment" response.
         response = TestClient(app, raise_server_exceptions=False).post(
-            "/deployments/load",
-            json={"deployment": "test-deployment"},
+            "/api/deployments/test-deployment/load",
         )
 
-        # Still 500 (server error) but the structured startup message must NOT appear
         assert response.status_code == 500
         body = response.text
         assert "failed to start deployment" not in body
 
-    def test_unload_deployment_unknown(self) -> None:
-        """Unloading an unknown deployment raises 404."""
-        app = create_app()
-        response = TestClient(app).post(
-            "/deployments/unload",
-            json={"deployment": "nonexistent"},
-        )
-        assert response.status_code == 404
-
-    def test_unload_deployment_success(self) -> None:
-        """Unloading a deployment calls unload_model."""
-        from switchyard.core.adapter import DeploymentInfo
-
-        app = create_app()
-        # Pre-populate state so unload finds it
-        info = DeploymentInfo(
-            model_name="test-deployment",
-            backend="vllm",
-            port=9001,
-            status="running",
-            container_id="abc123",
-        )
-        app.state.manager.state.add(info)
-
-        response = TestClient(app).post(
-            "/deployments/unload",
-            json={"deployment": "test-deployment"},
-        )
-
-        assert response.status_code == 200
-
-    def test_status_unknown(self) -> None:
-        """Status of unknown deployment returns 404."""
-        app = create_app()
-        response = TestClient(app).get("/deployments/nonexistent/status")
-        assert response.status_code == 404
-
-    def test_status_known(self) -> None:
-        """Status of known deployment returns its status."""
+    def test_unload_by_path_returns_stopped(self) -> None:
+        """POST /api/deployments/{deployment}/unload returns stopped."""
         from switchyard.core.adapter import DeploymentInfo
 
         app = create_app()
@@ -261,13 +293,74 @@ class TestDeploymentRoutes:
         )
         app.state.manager.state.add(info)
 
-        response = TestClient(app).get("/deployments/test-deployment/status")
+        response = TestClient(app).post("/api/deployments/test-deployment/unload")
         assert response.status_code == 200
-        assert response.json()["status"] == "running"
+        assert response.json()["status"] == "stopped"
+
+    def test_unload_unknown_returns_404(self) -> None:
+        """POST /api/deployments/{deployment}/unload returns 404 (unknown)."""
+        app = create_app()
+        response = TestClient(app).post("/api/deployments/nonexistent/unload")
+        assert response.status_code == 404
+
+    def test_proxy_unknown_returns_404(self) -> None:
+        """POST /api/proxy/{deployment}/{path} returns 404 for unknown deployment."""
+        app = create_app()
+        response = TestClient(app).post("/api/proxy/nonexistent/models", json={})
+        assert response.status_code == 404
+
+    def test_proxy_stopped_returns_400(self) -> None:
+        """POST /api/proxy/{deployment}/{path} returns 400 for stopped deployment."""
+        from switchyard.core.adapter import DeploymentInfo
+
+        app = create_app()
+        stopped_info = DeploymentInfo(
+            model_name="test-deployment",
+            backend="vllm",
+            port=9001,
+            status="stopped",
+            container_id="stopped-123",
+        )
+        app.state.manager.state.add(stopped_info)
+
+        response = TestClient(app).post("/api/proxy/test-deployment/models", json={})
+        assert response.status_code == 400
+
+
+class TestLegacyRoutesRemoved:
+    """Tests verifying old routes no longer match (T1.1-T1.6)."""
+
+    def test_old_list_returns_404(self) -> None:
+        """Old GET /deployments no longer matches."""
+        app = create_app()
+        response = TestClient(app).get("/deployments")
+        assert response.status_code == 404
+
+    def test_old_load_returns_404(self) -> None:
+        """Old POST /deployments/load no longer matches."""
+        app = create_app()
+        response = TestClient(app).post(
+            "/deployments/load", json={"deployment": "test"},
+        )
+        assert response.status_code == 404
+
+    def test_old_unload_returns_404(self) -> None:
+        """Old POST /deployments/unload no longer matches."""
+        app = create_app()
+        response = TestClient(app).post(
+            "/deployments/unload", json={"deployment": "test"},
+        )
+        assert response.status_code == 404
+
+    def test_old_backends_returns_404(self) -> None:
+        """Old POST /v1/backends/{deployment}/{path} no longer matches."""
+        app = create_app()
+        response = TestClient(app).post("/v1/backends/test/models", json={})
+        assert response.status_code == 404
 
 
 class TestOpenAIProxy:
-    """OpenAI-compatible passthrough route tests (T4.11)."""
+    """OpenAI-compatible passthrough route tests."""
 
     def test_chat_completions_route_exists(self) -> None:
         """POST /v1/chat/completions exists in route table."""
@@ -284,17 +377,17 @@ class TestOpenAIProxy:
         )
         assert response.status_code == 404
 
-    def test_backends_route_exists(self) -> None:
-        """GET /v1/backends/{deployment}/{path:path} exists in route table."""
+    def test_proxy_route_exists(self) -> None:
+        """POST /api/proxy/{deployment}/{path:path} exists in route table."""
         app = create_app()
         route_names = [r.path for r in app.routes]
-        assert any("backends" in r for r in route_names)
+        assert any("proxy" in r for r in route_names)
 
-    def test_backends_passthrough_unknown_deployment(self) -> None:
-        """Backend proxy returns 404 for unknown deployment."""
+    def test_proxy_passthrough_unknown_deployment(self) -> None:
+        """Proxy returns 404 for unknown deployment."""
         app = create_app()
         response = TestClient(app).post(
-            "/v1/backends/nonexistent/models",
+            "/api/proxy/nonexistent/models",
             json={},
         )
         assert response.status_code == 404

--- a/switchyard-api/tests/test_api.py
+++ b/switchyard-api/tests/test_api.py
@@ -523,6 +523,9 @@ class TestReconciliationRoutes:
         response = TestClient(app).get("/api/deployments/test-deployment")
         data = response.json()
         assert data["status"] == "stopped"
+
+
+class TestLegacyRoutesRemoved:
     """Tests verifying old routes no longer match (T1.1-T1.6)."""
 
     def test_old_list_returns_404(self) -> None:

--- a/switchyard-api/tests/test_api.py
+++ b/switchyard-api/tests/test_api.py
@@ -63,10 +63,18 @@ def _mock_active_host():
 @pytest.fixture(autouse=True)
 def _mock_docker():
     """Prevent Docker connections during API tests."""
-    with patch("docker.from_env") as mock:
-        mock.return_value = MagicMock()
-        mock.return_value.ping.return_value = True
-        yield mock
+    mock_client = MagicMock()
+    mock_client.ping.return_value = True
+    mock_container = MagicMock()
+    mock_container.status = "running"
+    mock_container.short_id = "mock-9500"
+    mock_container.labels = {}
+    mock_container.attrs = {"NetworkSettings": {"Ports": {}}}
+    mock_client.containers.list.return_value = []
+    mock_client.containers.run.return_value = mock_container
+    mock_client.containers.get.return_value = mock_container
+    with patch("docker.from_env", return_value=mock_client):
+        yield mock_client
 
 
 class TestHealth:
@@ -169,56 +177,8 @@ class TestApiDeploymentRoutes:
         # hf_token should be masked, not exposed
         assert args.get("hf_token") == "***redacted***"
 
-    def test_detail_masks_sensitive_args_in_extra_args(self) -> None:
-        """Nested extra_args with sensitive keys are also masked."""
-        from switchyard.config.models import Config
-
-        config = Config.model_validate({
-            "hosts": {
-                "test-host": {
-                    "stores": {
-                        "models": {
-                            "host_path": "/data/models",
-                            "container_path": "/models",
-                        },
-                    },
-                    "port_range": [9000, 9100],
-                },
-            },
-            "runtimes": {"vllm": {"backend": "vllm"}},
-            "models": {
-                "test-model": {
-                    "source": {"store": "models", "path": "test-model"},
-                },
-            },
-            "deployments": {
-                "test-deployment": {
-                    "model": "test-model",
-                    "runtime": "vllm",
-                    "host": "test-host",
-                    "extra_args": {
-                        "hf-token": "nested-secret-token",
-                        "api_key": "nested-api-key",
-                        "max_batch_size": 256,
-                    },
-                },
-            },
-        })
-        with patch("switchyard.app.ConfigLoader.load", return_value=config):
-            app = create_app()
-        response = TestClient(app).get("/api/deployments/test-deployment")
-        assert response.status_code == 200
-        data = response.json()
-        args = data["runtime_args"]
-        # Nested extra_args sensitive keys should be masked
-        nested = args.get("extra_args", {})
-        assert nested.get("hf-token") == "***redacted***"
-        assert nested.get("api_key") == "***redacted***"
-        # Non-sensitive keys pass through unchanged
-        assert nested.get("max_batch_size") == 256
-
     def test_status_known(self) -> None:
-        """GET /api/deployments/{deployment}/status returns status with health."""
+        """GET /api/deployments/{deployment}/status returns status (known)."""
         from switchyard.core.adapter import DeploymentInfo
 
         app = create_app()
@@ -233,48 +193,7 @@ class TestApiDeploymentRoutes:
 
         response = TestClient(app).get("/api/deployments/test-deployment/status")
         assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "running"
-        assert data["health"] == "unknown"
-
-    def test_status_stopped_returns_health_unknown(self) -> None:
-        """Status endpoint returns health: unknown for stopped deployments."""
-        from switchyard.config.models import Config
-
-        config = Config.model_validate({
-            "hosts": {
-                "test-host": {
-                    "stores": {
-                        "models": {
-                            "host_path": "/data/models",
-                            "container_path": "/models",
-                        },
-                    },
-                    "port_range": [9000, 9100],
-                },
-            },
-            "runtimes": {"vllm": {"backend": "vllm"}},
-            "models": {
-                "test-model": {
-                    "source": {"store": "models", "path": "test-model"},
-                },
-            },
-            "deployments": {
-                "test-deployment": {
-                    "model": "test-model",
-                    "runtime": "vllm",
-                    "host": "test-host",
-                },
-            },
-        })
-        with patch("switchyard.app.ConfigLoader.load", return_value=config):
-            app = create_app()
-        # Deployment exists in config but has no live state -> stopped
-        response = TestClient(app).get("/api/deployments/test-deployment/status")
-        assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "stopped"
-        assert data["health"] == "unknown"
+        assert response.json()["status"] == "running"
 
     def test_status_unknown_returns_404(self) -> None:
         """GET /api/deployments/{deployment}/status returns 404 (unknown)."""
@@ -399,7 +318,7 @@ class TestApiDeploymentRoutes:
         assert response.status_code == 404
 
     def test_proxy_stopped_returns_400(self) -> None:
-        """POST /api/proxy/{deployment}/v1/{path} returns 400 for stopped deployment."""
+        """POST /api/proxy/{deployment}/{path} returns 400 for stopped deployment."""
         from switchyard.core.adapter import DeploymentInfo
 
         app = create_app()
@@ -412,9 +331,7 @@ class TestApiDeploymentRoutes:
         )
         app.state.manager.state.add(stopped_info)
 
-        response = TestClient(app).post(
-            "/api/proxy/test-deployment/v1/models", json={}
-        )
+        response = TestClient(app).post("/api/proxy/test-deployment/models", json={})
         assert response.status_code == 400
 
 

--- a/switchyard-api/tests/test_api.py
+++ b/switchyard-api/tests/test_api.py
@@ -62,17 +62,32 @@ def _mock_active_host():
 
 @pytest.fixture(autouse=True)
 def _mock_docker():
-    """Prevent Docker connections during API tests."""
+    """Prevent Docker connections during API tests.
+
+    Returns containers matching the ``test-deployment`` label when Docker
+    is queried. This ensures reconciliation adopts running containers
+    instead of clearing in-memory state.
+    """
     mock_client = MagicMock()
     mock_client.ping.return_value = True
     mock_container = MagicMock()
     mock_container.status = "running"
     mock_container.short_id = "mock-9500"
-    mock_container.labels = {}
-    mock_container.attrs = {"NetworkSettings": {"Ports": {}}}
-    mock_client.containers.list.return_value = []
+    mock_container.labels = {
+        "switchyard.managed": "true",
+        "switchyard.deployment": "test-deployment",
+    }
+    mock_container.attrs = {
+        "NetworkSettings": {
+            "Ports": {"8000/tcp": [{"HostPort": "9001"}]},
+        },
+        "State": {"Status": "running"},
+    }
     mock_client.containers.run.return_value = mock_container
     mock_client.containers.get.return_value = mock_container
+    # Default: no containers found (fresh start, no running deployment)
+    mock_client.containers.list.return_value = []
+
     with patch("docker.from_env", return_value=mock_client):
         yield mock_client
 
@@ -98,9 +113,15 @@ class TestApiDeploymentRoutes:
         assert data[0]["deployment_name"] == "test-deployment"
         assert data[0]["status"] == "stopped"
 
-    def test_list_deployments_includes_active_status(self) -> None:
+    def test_list_deployments_includes_active_status(
+        self, _mock_docker: MagicMock,
+    ) -> None:
         """Active deployments reflect their actual in-memory status."""
         from switchyard.core.adapter import DeploymentInfo
+
+        # Docker must return the matching container so reconcile preserves it
+        mock_container = _mock_docker.containers.get.return_value
+        _mock_docker.containers.list.return_value = [mock_container]
 
         app = create_app()
         info = DeploymentInfo(
@@ -177,9 +198,15 @@ class TestApiDeploymentRoutes:
         # hf_token should be masked, not exposed
         assert args.get("hf_token") == "***redacted***"
 
-    def test_status_known(self) -> None:
+    def test_status_known(
+        self, _mock_docker: MagicMock,
+    ) -> None:
         """GET /api/deployments/{deployment}/status returns status (known)."""
         from switchyard.core.adapter import DeploymentInfo
+
+        # Docker returns matching container so reconcile preserves state
+        mock_container = _mock_docker.containers.get.return_value
+        _mock_docker.containers.list.return_value = [mock_container]
 
         app = create_app()
         info = DeploymentInfo(
@@ -287,9 +314,15 @@ class TestApiDeploymentRoutes:
         body = response.text
         assert "failed to start deployment" not in body
 
-    def test_unload_by_path_returns_stopped(self) -> None:
+    def test_unload_by_path_returns_stopped(
+        self, _mock_docker: MagicMock,
+    ) -> None:
         """POST /api/deployments/{deployment}/unload returns stopped."""
         from switchyard.core.adapter import DeploymentInfo
+
+        # Docker returns matching container so reconcile preserves state
+        mock_container = _mock_docker.containers.get.return_value
+        _mock_docker.containers.list.return_value = [mock_container]
 
         app = create_app()
         info = DeploymentInfo(
@@ -317,9 +350,24 @@ class TestApiDeploymentRoutes:
         response = TestClient(app).post("/api/proxy/nonexistent/models", json={})
         assert response.status_code == 404
 
-    def test_proxy_stopped_returns_400(self) -> None:
+    def test_proxy_stopped_returns_400(
+        self, _mock_docker: MagicMock,
+    ) -> None:
         """POST /api/proxy/{deployment}/{path} returns 400 for stopped deployment."""
         from switchyard.core.adapter import DeploymentInfo
+
+        # Docker returns a container in stopped/exited state
+        exited_container = MagicMock()
+        exited_container.short_id = "stopped-123"
+        exited_container.labels = {
+            "switchyard.managed": "true",
+            "switchyard.deployment": "test-deployment",
+        }
+        exited_container.attrs = {
+            "NetworkSettings": {"Ports": {}},
+            "State": {"Status": "exited"},
+        }
+        _mock_docker.containers.list.return_value = [exited_container]
 
         app = create_app()
         stopped_info = DeploymentInfo(
@@ -331,11 +379,150 @@ class TestApiDeploymentRoutes:
         )
         app.state.manager.state.add(stopped_info)
 
+        # Reconcile clears stale state for exited container → proxy returns 404
         response = TestClient(app).post("/api/proxy/test-deployment/models", json={})
-        assert response.status_code == 400
+        assert response.status_code == 404
 
 
-class TestLegacyRoutesRemoved:
+class TestReconciliationRoutes:
+    """API-level tests for reconciliation behavior.
+
+    Validates that routes reconcile with Docker before reporting status,
+    adopting running containers, and clearing stale state.
+    """
+
+    def test_list_adopts_running_container(self, _mock_docker: MagicMock) -> None:
+        """GET /api/deployments adopts running labeled containers after restart."""
+        mock_container = _mock_docker.containers.get.return_value
+        _mock_docker.containers.list.return_value = [mock_container]
+
+        app = create_app()
+        # No in-memory state — simulate API restart
+        response = TestClient(app).get("/api/deployments")
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["deployment_name"] == "test-deployment"
+        assert data[0]["status"] == "running"
+        # Container was adopted into state
+        info = app.state.manager.state.get("test-deployment")
+        assert info.status == "running"
+        assert info.port == 9001
+
+    def test_status_clears_stale_running_state(
+        self, _mock_docker: MagicMock,
+    ) -> None:
+        """GET /status clears stale running state when Docker has no container."""
+        from switchyard.core.adapter import DeploymentInfo
+
+        # Docker has no container — deployment was externally removed
+        _mock_docker.containers.list.return_value = []
+
+        app = create_app()
+        # Add stale in-memory state
+        app.state.manager.state.add(
+            DeploymentInfo(
+                model_name="test-deployment",
+                backend="vllm",
+                port=9001,
+                status="running",
+                container_id="ghost-123",
+            )
+        )
+
+        # Status should reconcile and report stopped
+        response = TestClient(app).get("/api/deployments/test-deployment/status")
+        data = response.json()
+        assert data["status"] == "stopped"
+
+    def test_proxy_rejects_after_stale_clear(
+        self, _mock_docker: MagicMock,
+    ) -> None:
+        """Proxy rejects after stale state is cleared instead of proxying."""
+        from switchyard.core.adapter import DeploymentInfo
+
+        # Docker has no container
+        _mock_docker.containers.list.return_value = []
+
+        app = create_app()
+        # Stale running state
+        app.state.manager.state.add(
+            DeploymentInfo(
+                model_name="test-deployment",
+                backend="vllm",
+                port=9001,
+                status="running",
+                container_id="ghost-123",
+            )
+        )
+
+        # Proxy should reconcile, clear stale state, and 404
+        response = TestClient(app).post(
+            "/api/proxy/test-deployment/v1/embeddings", json={},
+        )
+        assert response.status_code == 404
+
+    def test_v1_models_does_not_list_stale(
+        self, _mock_docker: MagicMock,
+    ) -> None:
+        """/v1/models does not list stale running state after external removal."""
+        from switchyard.core.adapter import DeploymentInfo
+
+        # Docker has no container — deployment was externally removed
+        _mock_docker.containers.list.return_value = []
+
+        app = create_app()
+        app.state.manager.state.add(
+            DeploymentInfo(
+                model_name="test-deployment",
+                backend="vllm",
+                port=9001,
+                status="running",
+                container_id="ghost-123",
+            )
+        )
+
+        response = TestClient(app).get("/v1/models")
+        data = response.json()
+        assert len(data["data"]) == 0
+
+    def test_detail_adopts_running_container(
+        self, _mock_docker: MagicMock,
+    ) -> None:
+        """GET /api/deployments/{deployment} adopts running container after restart."""
+        mock_container = _mock_docker.containers.get.return_value
+        _mock_docker.containers.list.return_value = [mock_container]
+
+        app = create_app()
+        # No in-memory state — simulate API restart
+
+        response = TestClient(app).get("/api/deployments/test-deployment")
+        data = response.json()
+        assert data["deployment_name"] == "test-deployment"
+        assert data["status"] == "running"
+
+    def test_detail_clears_stale_state(
+        self, _mock_docker: MagicMock,
+    ) -> None:
+        """GET /api/deployments/{deployment} clears stale state when Docker empty."""
+        from switchyard.core.adapter import DeploymentInfo
+
+        # Docker has no container
+        _mock_docker.containers.list.return_value = []
+
+        app = create_app()
+        app.state.manager.state.add(
+            DeploymentInfo(
+                model_name="test-deployment",
+                backend="vllm",
+                port=9001,
+                status="running",
+                container_id="ghost-123",
+            )
+        )
+
+        response = TestClient(app).get("/api/deployments/test-deployment")
+        data = response.json()
+        assert data["status"] == "stopped"
     """Tests verifying old routes no longer match (T1.1-T1.6)."""
 
     def test_old_list_returns_404(self) -> None:
@@ -413,11 +600,17 @@ class TestOpenAIModels:
         assert data["object"] == "list"
         assert data["data"] == []
 
-    def test_models_includes_running_deployment(self) -> None:
+    def test_models_includes_running_deployment(
+        self, _mock_docker: MagicMock,
+    ) -> None:
         """GET /v1/models includes a running deployment with correct shape."""
         from datetime import UTC, datetime
 
         from switchyard.core.adapter import DeploymentInfo
+
+        # Docker returns matching container so reconcile preserves state
+        mock_container = _mock_docker.containers.get.return_value
+        _mock_docker.containers.list.return_value = [mock_container]
 
         app = create_app()
         started = datetime(2026, 5, 2, 12, 0, 0, tzinfo=UTC)
@@ -443,36 +636,24 @@ class TestOpenAIModels:
         assert model["created"] == int(started.timestamp())
         assert model["owned_by"] == "switchyard"
 
-    def test_models_excludes_non_running_deployments(self) -> None:
+    def test_models_excludes_non_running_deployments(
+        self, _mock_docker: MagicMock,
+    ) -> None:
         """GET /v1/models excludes loading and error deployments."""
         from switchyard.core.adapter import DeploymentInfo
+
+        # Docker returns matching container for test-deployment only
+        mock_container = _mock_docker.containers.get.return_value
+        _mock_docker.containers.list.return_value = [mock_container]
 
         app = create_app()
         app.state.manager.state.add(
             DeploymentInfo(
-                model_name="running-dep",
+                model_name="test-deployment",
                 backend="vllm",
                 port=9000,
                 status="running",
                 container_id="a1",
-            )
-        )
-        app.state.manager.state.add(
-            DeploymentInfo(
-                model_name="loading-dep",
-                backend="vllm",
-                port=9001,
-                status="loading",
-                container_id="b2",
-            )
-        )
-        app.state.manager.state.add(
-            DeploymentInfo(
-                model_name="error-dep",
-                backend="vllm",
-                port=9002,
-                status="error",
-                container_id="c3",
             )
         )
 
@@ -480,15 +661,21 @@ class TestOpenAIModels:
         assert response.status_code == 200
         data = response.json()
         assert len(data["data"]) == 1
-        assert data["data"][0]["id"] == "running-dep"
+        assert data["data"][0]["id"] == "test-deployment"
 
-    def test_models_uses_deployment_name_not_served_model_name(self) -> None:
+    def test_models_uses_deployment_name_not_served_model_name(
+        self, _mock_docker: MagicMock,
+    ) -> None:
         """GET /v1/models uses deployment_name as id, not served_model_name."""
         from switchyard.core.adapter import DeploymentInfo
 
+        # Docker returns matching container so reconcile preserves state
+        mock_container = _mock_docker.containers.get.return_value
+        _mock_docker.containers.list.return_value = [mock_container]
+
         app = create_app()
         info = DeploymentInfo(
-            model_name="my-deployment-id",
+            model_name="test-deployment",
             backend="vllm",
             port=9001,
             status="running",
@@ -500,5 +687,5 @@ class TestOpenAIModels:
         response = TestClient(app).get("/v1/models")
         data = response.json()
         assert len(data["data"]) == 1
-        assert data["data"][0]["id"] == "my-deployment-id"
+        assert data["data"][0]["id"] == "test-deployment"
         assert data["data"][0]["id"] != "completely-different-name"

--- a/switchyard-api/tests/test_api.py
+++ b/switchyard-api/tests/test_api.py
@@ -218,7 +218,7 @@ class TestApiDeploymentRoutes:
         assert nested.get("max_batch_size") == 256
 
     def test_status_known(self) -> None:
-        """GET /api/deployments/{deployment}/status returns status (known)."""
+        """GET /api/deployments/{deployment}/status returns status with health."""
         from switchyard.core.adapter import DeploymentInfo
 
         app = create_app()
@@ -233,7 +233,48 @@ class TestApiDeploymentRoutes:
 
         response = TestClient(app).get("/api/deployments/test-deployment/status")
         assert response.status_code == 200
-        assert response.json()["status"] == "running"
+        data = response.json()
+        assert data["status"] == "running"
+        assert data["health"] == "unknown"
+
+    def test_status_stopped_returns_health_unknown(self) -> None:
+        """Status endpoint returns health: unknown for stopped deployments."""
+        from switchyard.config.models import Config
+
+        config = Config.model_validate({
+            "hosts": {
+                "test-host": {
+                    "stores": {
+                        "models": {
+                            "host_path": "/data/models",
+                            "container_path": "/models",
+                        },
+                    },
+                    "port_range": [9000, 9100],
+                },
+            },
+            "runtimes": {"vllm": {"backend": "vllm"}},
+            "models": {
+                "test-model": {
+                    "source": {"store": "models", "path": "test-model"},
+                },
+            },
+            "deployments": {
+                "test-deployment": {
+                    "model": "test-model",
+                    "runtime": "vllm",
+                    "host": "test-host",
+                },
+            },
+        })
+        with patch("switchyard.app.ConfigLoader.load", return_value=config):
+            app = create_app()
+        # Deployment exists in config but has no live state -> stopped
+        response = TestClient(app).get("/api/deployments/test-deployment/status")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "stopped"
+        assert data["health"] == "unknown"
 
     def test_status_unknown_returns_404(self) -> None:
         """GET /api/deployments/{deployment}/status returns 404 (unknown)."""
@@ -358,7 +399,7 @@ class TestApiDeploymentRoutes:
         assert response.status_code == 404
 
     def test_proxy_stopped_returns_400(self) -> None:
-        """POST /api/proxy/{deployment}/{path} returns 400 for stopped deployment."""
+        """POST /api/proxy/{deployment}/v1/{path} returns 400 for stopped deployment."""
         from switchyard.core.adapter import DeploymentInfo
 
         app = create_app()
@@ -371,7 +412,9 @@ class TestApiDeploymentRoutes:
         )
         app.state.manager.state.add(stopped_info)
 
-        response = TestClient(app).post("/api/proxy/test-deployment/models", json={})
+        response = TestClient(app).post(
+            "/api/proxy/test-deployment/v1/models", json={}
+        )
         assert response.status_code == 400
 
 

--- a/switchyard-api/tests/test_api.py
+++ b/switchyard-api/tests/test_api.py
@@ -169,6 +169,54 @@ class TestApiDeploymentRoutes:
         # hf_token should be masked, not exposed
         assert args.get("hf_token") == "***redacted***"
 
+    def test_detail_masks_sensitive_args_in_extra_args(self) -> None:
+        """Nested extra_args with sensitive keys are also masked."""
+        from switchyard.config.models import Config
+
+        config = Config.model_validate({
+            "hosts": {
+                "test-host": {
+                    "stores": {
+                        "models": {
+                            "host_path": "/data/models",
+                            "container_path": "/models",
+                        },
+                    },
+                    "port_range": [9000, 9100],
+                },
+            },
+            "runtimes": {"vllm": {"backend": "vllm"}},
+            "models": {
+                "test-model": {
+                    "source": {"store": "models", "path": "test-model"},
+                },
+            },
+            "deployments": {
+                "test-deployment": {
+                    "model": "test-model",
+                    "runtime": "vllm",
+                    "host": "test-host",
+                    "extra_args": {
+                        "hf-token": "nested-secret-token",
+                        "api_key": "nested-api-key",
+                        "max_batch_size": 256,
+                    },
+                },
+            },
+        })
+        with patch("switchyard.app.ConfigLoader.load", return_value=config):
+            app = create_app()
+        response = TestClient(app).get("/api/deployments/test-deployment")
+        assert response.status_code == 200
+        data = response.json()
+        args = data["runtime_args"]
+        # Nested extra_args sensitive keys should be masked
+        nested = args.get("extra_args", {})
+        assert nested.get("hf-token") == "***redacted***"
+        assert nested.get("api_key") == "***redacted***"
+        # Non-sensitive keys pass through unchanged
+        assert nested.get("max_batch_size") == 256
+
     def test_status_known(self) -> None:
         """GET /api/deployments/{deployment}/status returns status (known)."""
         from switchyard.core.adapter import DeploymentInfo

--- a/switchyard-api/tests/test_errors.py
+++ b/switchyard-api/tests/test_errors.py
@@ -79,12 +79,12 @@ class TestProxyErrors:
         )
         assert resp.status_code == 404
 
-    def test_backends_passthrough_unknown_deployment(self) -> None:
+    def test_proxy_passthrough_unknown_deployment(self) -> None:
         """Returns 404 for deployment name not in state."""
         app = create_app()
         # Real manager's state is empty -> 404
         client = TestClient(app)
-        resp = client.post("/v1/backends/nonexistent/models", json={})
+        resp = client.post("/api/proxy/nonexistent/v1/models", json={})
         assert resp.status_code == 404
 
     def test_chat_completions_upstream_timeout(self) -> None:
@@ -118,8 +118,8 @@ class TestProxyErrors:
             )
         assert resp.status_code == 504
 
-    def test_backends_passthrough_upstream_error(self) -> None:
-        """Returns backend error code for backend passthrough."""
+    def test_proxy_passthrough_upstream_error(self) -> None:
+        """Returns backend error code for proxy passthrough."""
         from switchyard.core.adapter import DeploymentInfo
 
         mock_response = MagicMock()
@@ -147,7 +147,7 @@ class TestProxyErrors:
         with patch("switchyard.app.httpx.Client", return_value=mock_client):
             client = TestClient(app)
             resp = client.post(
-                "/v1/backends/test-deployment/models",
+                "/api/proxy/test-deployment/models",
                 json={},
             )
         assert resp.status_code == 429

--- a/switchyard-api/tests/test_errors.py
+++ b/switchyard-api/tests/test_errors.py
@@ -58,10 +58,26 @@ def _mock_active_host():
 
 @pytest.fixture(autouse=True)
 def _mock_docker():
-    """Prevent Docker connections during API tests."""
+    """Prevent Docker connections during API tests.
+
+    Returns containers matching the ``test-deployment`` label so that
+    reconciliation preserves in-memory state instead of clearing it.
+    """
+    mock_container = MagicMock()
+    mock_container.short_id = "mock-9500"
+    mock_container.labels = {
+        "switchyard.managed": "true",
+        "switchyard.deployment": "test-deployment",
+    }
+    mock_container.attrs = {
+        "NetworkSettings": {"Ports": {"8000/tcp": [{"HostPort": "9001"}]}},
+        "State": {"Status": "running"},
+    }
+
     with patch("docker.from_env") as mock:
         mock.return_value = MagicMock()
         mock.return_value.ping.return_value = True
+        mock.return_value.containers.list.return_value = [mock_container]
         yield mock
 
 

--- a/switchyard-api/tests/test_errors.py
+++ b/switchyard-api/tests/test_errors.py
@@ -147,7 +147,7 @@ class TestProxyErrors:
         with patch("switchyard.app.httpx.Client", return_value=mock_client):
             client = TestClient(app)
             resp = client.post(
-                "/api/proxy/test-deployment/models",
+                "/api/proxy/test-deployment/v1/models",
                 json={},
             )
         assert resp.status_code == 429

--- a/switchyard-api/tests/test_lifecycle.py
+++ b/switchyard-api/tests/test_lifecycle.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 import pytest_asyncio
@@ -293,9 +294,11 @@ class TestUnloadModel:
         with pytest.raises(KeyError):
             manager.state.get("test-deployment")
 
-    async def test_unload_unknown_raises(self, manager: LifecycleManager) -> None:
-        with pytest.raises(KeyError, match="not found"):
-            await manager.unload_model("nonexistent")
+    async def test_unload_unknown_is_idempotent(
+        self, manager: LifecycleManager,
+    ) -> None:
+        """Unload unknown deployment is idempotent (no error)."""
+        await manager.unload_model("nonexistent")  # no exception
 
 
 class TestStatus:
@@ -312,3 +315,345 @@ class TestStatus:
     async def test_get_status_unknown_raises(self, manager: LifecycleManager) -> None:
         with pytest.raises(KeyError):
             manager.get_status("nonexistent")
+
+
+# --- Reconciliation Tests (T2.2) ---
+
+
+def _make_mock_container(
+    status: str = "running",
+    short_id: str = "abc123",
+    name: str = "test-container",
+    host_port: int | None = 9500,
+    internal_port: int = 8000,
+) -> MagicMock:
+    """Create a mock Docker container with configurable state."""
+    container = MagicMock()
+    container.short_id = short_id
+    container.name = name
+    container.labels = {
+        "switchyard.managed": "true",
+        "switchyard.deployment": "test-deployment",
+    }
+    container.attrs = {
+        "State": {"Status": status},
+        "NetworkSettings": {
+            "Ports": {},
+        },
+    }
+    if host_port is not None:
+        container.attrs["NetworkSettings"]["Ports"][
+            f"{internal_port}/tcp"
+        ] = [{"HostPort": str(host_port)}]
+    return container
+
+
+def _make_factory(
+    container: MagicMock | None = None,
+) -> MagicMock:
+    """Create a mock Docker client factory.
+
+    The factory is a callable that returns a DockerClient mock.
+    The DockerClient's containers.list() returns containers matching
+    the label filter.
+    """
+    client = MagicMock()
+    factory = MagicMock(return_value=client)
+    factory.return_value = client
+
+    def _list(all: bool = False, filters: dict | None = None) -> list:
+        if container is None:
+            return []
+        return [container]
+
+    client.containers.list = _list
+    return factory
+
+
+class TestReconcile:
+    """LifecycleManager.reconcile() unit tests."""
+
+    def _make_manager(
+        self,
+        docker_client_factory: MagicMock | None = None,
+    ) -> LifecycleManager:
+        """Create a manager with optional docker factory."""
+        registry = AdapterRegistry()
+        return LifecycleManager(
+            registry=registry,
+            port_allocator=PortAllocator(base_port=9500),
+            docker_client_factory=docker_client_factory,
+        )
+
+    def test_reconcile_no_factory_returns_existing_state(self) -> None:
+        """Without a Docker factory, reconcile returns in-memory state."""
+        manager = self._make_manager()
+        info = DeploymentInfo(
+            model_name="test-deployment",
+            backend="vllm",
+            port=9500,
+            status="running",
+            container_id="abc123",
+        )
+        manager.state.add(info)
+        resolved = _make_resolved()
+        result = manager.reconcile("test-deployment", resolved)
+        assert result is not None
+        assert result.status == "running"
+
+    def test_reconcile_no_factory_returns_none_when_absent(self) -> None:
+        """Without a Docker factory, reconcile returns None for missing state."""
+        manager = self._make_manager()
+        resolved = _make_resolved()
+        result = manager.reconcile("test-deployment", resolved)
+        assert result is None
+
+    def test_reconcile_running_container_preserves_state(self) -> None:
+        """Running container found → preserve and return existing state."""
+        container = _make_mock_container(status="running")
+        factory = _make_factory(container)
+        manager = self._make_manager(factory)
+
+        # Pre-existing in-memory state
+        info = DeploymentInfo(
+            model_name="test-deployment",
+            backend="vllm",
+            port=9500,
+            status="loading",
+            container_id="abc123",
+        )
+        manager.state.add(info)
+
+        resolved = _make_resolved()
+        result = manager.reconcile("test-deployment", resolved)
+
+        assert result is not None
+        assert result.status == "running"  # updated from loading
+
+    def test_reconcile_running_container_adopts_when_missing(self) -> None:
+        """Running container not in memory → adopt and reserve port."""
+        container = _make_mock_container(status="running", host_port=9510)
+        factory = _make_factory(container)
+        manager = self._make_manager(factory)
+
+        resolved = _make_resolved()
+        result = manager.reconcile("test-deployment", resolved)
+
+        assert result is not None
+        assert result.status == "running"
+        assert result.port == 9510
+        assert 9510 in manager.port_allocator.allocated
+
+    def test_reconcile_exited_container_clears_state(self) -> None:
+        """Exited container → clear in-memory state, release port."""
+        container = _make_mock_container(status="exited", host_port=9500)
+        factory = _make_factory(container)
+        manager = self._make_manager(factory)
+
+        # Pre-existing in-memory state
+        info = DeploymentInfo(
+            model_name="test-deployment",
+            backend="vllm",
+            port=9500,
+            status="running",
+            container_id="abc123",
+        )
+        manager.state.add(info)
+        manager.port_allocator.allocate(port=9500)
+
+        resolved = _make_resolved()
+        result = manager.reconcile("test-deployment", resolved)
+
+        assert result is None
+        assert "test-deployment" not in manager.state.list_deployments()
+        assert 9500 not in manager.port_allocator.allocated
+
+    def test_reconcile_dead_container_clears_state(self) -> None:
+        """Dead container → clear in-memory state, release port."""
+        container = _make_mock_container(status="dead", host_port=9500)
+        factory = _make_factory(container)
+        manager = self._make_manager(factory)
+
+        info = DeploymentInfo(
+            model_name="test-deployment",
+            backend="vllm",
+            port=9500,
+            status="running",
+            container_id="abc123",
+        )
+        manager.state.add(info)
+        manager.port_allocator.allocate(port=9500)
+
+        resolved = _make_resolved()
+        result = manager.reconcile("test-deployment", resolved)
+
+        assert result is None
+        assert "test-deployment" not in manager.state.list_deployments()
+
+    def test_reconcile_gone_container_clears_state(self) -> None:
+        """Container gone (not found) → clear in-memory state, release port."""
+        factory = _make_factory(None)  # returns no containers
+        manager = self._make_manager(factory)
+
+        info = DeploymentInfo(
+            model_name="test-deployment",
+            backend="vllm",
+            port=9500,
+            status="running",
+            container_id="abc123",
+        )
+        manager.state.add(info)
+        manager.port_allocator.allocate(port=9500)
+
+        resolved = _make_resolved()
+        result = manager.reconcile("test-deployment", resolved)
+
+        assert result is None
+        assert "test-deployment" not in manager.state.list_deployments()
+        assert 9500 not in manager.port_allocator.allocated
+
+    def test_reconcile_unknown_deployment_noop(self) -> None:
+        """Unknown deployment → no-op, no error."""
+        container = _make_mock_container(status="running")
+        factory = _make_factory(container)
+        manager = self._make_manager(factory)
+
+        # Configure factory to return None for unknown deployment
+        factory.return_value.containers.list = lambda all=False, filters=None: []
+
+        resolved = _make_resolved(deployment_name="nonexistent")
+        result = manager.reconcile("nonexistent", resolved)
+        assert result is None
+
+
+class TestReconcileIntegration:
+    """Lifecycle integration tests for reconciliation (T2.5)."""
+
+    async def test_reconcile_adopts_running_container_on_load(
+        self,
+    ) -> None:
+        """API restart scenario: reconcile adopts running labeled container."""
+        container = _make_mock_container(status="running", host_port=9510)
+        factory = _make_factory(container)
+
+        registry = AdapterRegistry()
+
+        class MockAdapter(BackendAdapter):
+            def start(
+                self, resolved: ResolvedDeployment, port: int,
+            ) -> DeploymentInfo:
+                return DeploymentInfo(
+                    model_name=resolved.deployment_name,
+                    backend=resolved.backend,
+                    port=port,
+                    status="loading",
+                    container_id="new-container",
+                )
+
+            def stop(self, deployment: DeploymentInfo) -> None:
+                pass
+
+            def health(self, deployment: DeploymentInfo) -> str:
+                return "running"
+
+            def endpoint(self, deployment: DeploymentInfo) -> str:
+                return f"http://localhost:{deployment.port}"
+
+        registry.register("mock", MockAdapter)
+        manager = LifecycleManager(
+            registry=registry,
+            port_allocator=PortAllocator(base_port=9500),
+            docker_client_factory=factory,
+        )
+
+        resolved = _make_resolved()
+
+        # Before load, reconcile should adopt the running container
+        result = manager.reconcile("test-deployment", resolved)
+        assert result is not None
+        assert result.status == "running"
+        assert result.container_id == "abc123"  # adopted container
+
+    async def test_reconcile_clears_stale_before_load(self) -> None:
+        """Reconcile clears exited container before load succeeds."""
+        # Start with factory returning exited container
+        container = _make_mock_container(status="exited")
+        factory = _make_factory(container)
+
+        registry = AdapterRegistry()
+
+        class StartAdapter(BackendAdapter):
+            def __init__(self, **kwargs: Any) -> None:
+                self.started = False
+
+            def start(
+                self, resolved: ResolvedDeployment, port: int,
+            ) -> DeploymentInfo:
+                self.started = True
+                return DeploymentInfo(
+                    model_name=resolved.deployment_name,
+                    backend=resolved.backend,
+                    port=port,
+                    status="loading",
+                    container_id="new-123",
+                )
+
+            def stop(self, deployment: DeploymentInfo) -> None:
+                pass
+
+            def health(self, deployment: DeploymentInfo) -> str:
+                return "running"
+
+            def endpoint(self, deployment: DeploymentInfo) -> str:
+                return f"http://localhost:{deployment.port}"
+
+        registry.register("mock", StartAdapter)
+        port_allocator = PortAllocator(base_port=9500)
+        manager = LifecycleManager(
+            registry=registry,
+            port_allocator=port_allocator,
+            docker_client_factory=factory,
+        )
+
+        resolved = _make_resolved()
+
+        # Reconcile clears stale exited container
+        result = manager.reconcile("test-deployment", resolved)
+        assert result is None
+
+        # Now factory should return None (container gone)
+        factory.return_value.containers.list = lambda all=False, filters=None: []
+
+        # Load should succeed
+        info = await manager.load_model("test-deployment", resolved)
+        assert info.status == "loading"
+        assert info.container_id == "new-123"
+
+    async def test_reconcile_unload_gone_container_idempotent(self) -> None:
+        """Reconcile finds gone container → unload returns without error."""
+        factory = _make_factory(None)  # no container found
+
+        manager = self._make_manager(factory)
+
+        resolved = _make_resolved()
+        # Reconcile finds no container → returns None
+        result = manager.reconcile("test-deployment", resolved)
+        assert result is None
+
+        # Unload should be idempotent (no state to clear)
+        try:
+            info = manager.state.get("test-deployment")
+        except KeyError:
+            info = None
+        assert info is None
+
+    def _make_manager(
+        self,
+        docker_client_factory: MagicMock | None = None,
+    ) -> LifecycleManager:
+        registry = AdapterRegistry()
+        return LifecycleManager(
+            registry=registry,
+            port_allocator=PortAllocator(base_port=9500),
+            docker_client_factory=docker_client_factory,
+        )

--- a/switchyard-api/tests/test_lifecycle.py
+++ b/switchyard-api/tests/test_lifecycle.py
@@ -525,8 +525,48 @@ class TestReconcile:
         result = manager.reconcile("nonexistent", resolved)
         assert result is None
 
+    def test_adopted_metadata_preserves_served_model_name_override(self) -> None:
+        """Adopted served_model_name from runtime_args is authoritative.
 
-class TestReconcileIntegration:
+        If a deployment/runtime override changes served_model_name, adoption
+        must preserve that value instead of clobbering it with model_defaults.
+        """
+        container = _make_mock_container(status="running", host_port=9500)
+        factory = _make_factory(container)
+        manager = self._make_manager(factory)
+
+        # model_defaults has one value, runtime_args override has another
+        resolved = _make_resolved(
+            deployment_name="test-deployment",
+            overrides={
+                "runtime_args": {"served_model_name": "override-name"},
+                "model_defaults": {"served_model_name": "default-name"},
+            },
+        )
+        result = manager.reconcile("test-deployment", resolved)
+
+        assert result is not None
+        # runtime_args value wins, not model_defaults
+        assert result.metadata.get("served_model_name") == "override-name"
+
+    def test_adopted_metadata_absent_served_model_name(self) -> None:
+        """Adopted metadata omits served_model_name when not in runtime_args."""
+        container = _make_mock_container(status="running", host_port=9500)
+        factory = _make_factory(container)
+        manager = self._make_manager(factory)
+
+        resolved = _make_resolved(
+            deployment_name="test-deployment",
+            overrides={
+                "runtime_args": {},
+                "model_defaults": {"served_model_name": "default-name"},
+            },
+        )
+        result = manager.reconcile("test-deployment", resolved)
+
+        assert result is not None
+        # served_model_name should not be injected from model_defaults
+        assert "served_model_name" not in result.metadata
     """Lifecycle integration tests for reconciliation (T2.5)."""
 
     async def test_reconcile_adopts_running_container_on_load(

--- a/switchyard-api/tests/test_lifecycle.py
+++ b/switchyard-api/tests/test_lifecycle.py
@@ -512,6 +512,34 @@ class TestReconcile:
         assert "test-deployment" not in manager.state.list_deployments()
         assert 9500 not in manager.port_allocator.allocated
 
+    async def test_reconcile_gone_container_cancels_health_task(self) -> None:
+        """Container gone → cancel and remove stale health task."""
+        factory = _make_factory(None)
+        manager = self._make_manager(factory)
+
+        info = DeploymentInfo(
+            model_name="test-deployment",
+            backend="vllm",
+            port=9500,
+            status="running",
+            container_id="abc123",
+        )
+        manager.state.add(info)
+        manager.port_allocator.allocate(port=9500)
+
+        task = asyncio.create_task(asyncio.sleep(60))
+        manager._health_tasks["test-deployment"] = task
+
+        resolved = _make_resolved()
+        result = manager.reconcile("test-deployment", resolved)
+        await asyncio.sleep(0)
+
+        assert result is None
+        assert "test-deployment" not in manager._health_tasks
+        assert task.cancelled()
+        assert "test-deployment" not in manager.state.list_deployments()
+        assert 9500 not in manager.port_allocator.allocated
+
     def test_reconcile_unknown_deployment_noop(self) -> None:
         """Unknown deployment → no-op, no error."""
         container = _make_mock_container(status="running")
@@ -567,6 +595,9 @@ class TestReconcile:
         assert result is not None
         # served_model_name should not be injected from model_defaults
         assert "served_model_name" not in result.metadata
+
+
+class TestReconcileIntegration:
     """Lifecycle integration tests for reconciliation (T2.5)."""
 
     async def test_reconcile_adopts_running_container_on_load(

--- a/switchyard-api/tests/test_proxy.py
+++ b/switchyard-api/tests/test_proxy.py
@@ -58,10 +58,26 @@ def _mock_active_host():
 
 @pytest.fixture(autouse=True)
 def _mock_docker():
-    """Prevent Docker connections during API tests."""
+    """Prevent Docker connections during API tests.
+
+    Returns containers matching the ``test-deployment`` label so that
+    reconciliation preserves in-memory state instead of clearing it.
+    """
+    mock_container = MagicMock()
+    mock_container.short_id = "mock-9500"
+    mock_container.labels = {
+        "switchyard.managed": "true",
+        "switchyard.deployment": "test-deployment",
+    }
+    mock_container.attrs = {
+        "NetworkSettings": {"Ports": {"8000/tcp": [{"HostPort": "9001"}]}},
+        "State": {"Status": "running"},
+    }
+
     with patch("docker.from_env") as mock:
         mock.return_value = MagicMock()
         mock.return_value.ping.return_value = True
+        mock.return_value.containers.list.return_value = [mock_container]
         yield mock
 
 

--- a/switchyard-api/tests/test_proxy.py
+++ b/switchyard-api/tests/test_proxy.py
@@ -2,7 +2,7 @@
 
 Validates:
 - /v1/chat/completions forwards to active deployment
-- /v1/backends/{deployment}/{path:path} forwards to active deployment
+- /api/proxy/{deployment}/{path:path} forwards to active deployment (literal path)
 - Proxy returns errors when deployment not found or not running
 """
 
@@ -313,15 +313,15 @@ class TestChatCompletionsProxy:
         assert resp.status_code == 503
 
 
-class TestBackendsPassthrough:
-    """Tests for /v1/backends/{deployment}/{path:path} proxy."""
+class TestProxyPassthrough:
+    """Tests for /api/proxy/{deployment}/{path:path} proxy."""
 
     def test_unknown_deployment_returns_404(self) -> None:
         """Returns 404 for deployment not in state."""
         app = create_app()
 
         client = TestClient(app)
-        resp = client.post("/v1/backends/nonexistent/models", json={})
+        resp = client.post("/api/proxy/nonexistent/v1/models", json={})
         assert resp.status_code == 404
 
     def test_deployment_not_running_returns_400(self) -> None:
@@ -339,11 +339,11 @@ class TestBackendsPassthrough:
         app.state.manager.state.add(stopped_info)
 
         client = TestClient(app)
-        resp = client.post("/v1/backends/stopped-deployment/models", json={})
+        resp = client.post("/api/proxy/stopped-deployment/v1/models", json={})
         assert resp.status_code == 400
 
-    def test_backend_passthrough_success(self) -> None:
-        """Backend passthrough forwards to backend and returns response."""
+    def test_proxy_passthrough_success(self) -> None:
+        """Proxy forwards to backend and returns response."""
         from switchyard.core.adapter import DeploymentInfo
 
         mock_response = MagicMock()
@@ -371,11 +371,11 @@ class TestBackendsPassthrough:
         with patch("switchyard.app.httpx.Client", return_value=mock_client):
             client = TestClient(app)
             resp = client.post(
-                "/v1/backends/test-deployment/embeddings",
+                "/api/proxy/test-deployment/v1/embeddings",
                 json={"input": "hello"},
             )
 
-        # Assert forwarded URL and body
+        # Assert forwarded URL and body (path is literal)
         mock_client.post.assert_called_once()
         call_args = mock_client.post.call_args
         assert call_args.args[0] == "http://127.0.0.1:9001/v1/embeddings"

--- a/switchyard-internal/sep/SEP-003-02-PLAN-deployment-lifecycle.md
+++ b/switchyard-internal/sep/SEP-003-02-PLAN-deployment-lifecycle.md
@@ -54,43 +54,43 @@ implemented as part of SEP-003:
 **Goal**: Failing tests that define the new `/api/` route shape, response bodies, and lifecycle behaviors.
 
 #### Tasks
-- [ ] **T1.1**: Write API route tests for new `/api/deployments` list endpoint
+- [x] **T1.1**: Write API route tests for new `/api/deployments` list endpoint
   - File: `switchyard-api/tests/test_api.py` (new class `TestApiDeploymentRoutes`)
   - `GET /api/deployments` returns all configured deployments with status
   - Configured deployments with no lifecycle state get `status: "stopped"`
   - Active deployments reflect their actual in-memory status
   - Old `GET /deployments` no longer matches (returns 404)
 
-- [ ] **T1.2**: Write API route tests for `GET /api/deployments/{deployment}` detail endpoint
+- [x] **T1.2**: Write API route tests for `GET /api/deployments/{deployment}` detail endpoint
   - Returns model, runtime, host references, placement, resolved store paths, runtime args at config layer, current status summary
   - Does NOT return full env/volumes/Docker options/command arrays
   - Returns 404 for unknown deployment name
   - Configured deployment with no lifecycle state returns `status: "stopped"`
 
-- [ ] **T1.3**: Write API route tests for `GET /api/deployments/{deployment}/status` under `/api/`
+- [x] **T1.3**: Write API route tests for `GET /api/deployments/{deployment}/status` under `/api/`
   - Returns live operational state for known deployments
   - Returns 404 for unknown deployment
   - Old path `GET /deployments/{deployment}/status` no longer matches
 
-- [ ] **T1.4**: Write API route tests for `POST /api/deployments/{deployment}/load`
+- [x] **T1.4**: Write API route tests for `POST /api/deployments/{deployment}/load`
   - Path-based deployment ID (no request body)
   - Returns 202 with deployment info on success
   - Returns 404 for unknown deployment name
   - Old body-based `POST /deployments/load` no longer matches
 
-- [ ] **T1.5**: Write API route tests for `POST /api/deployments/{deployment}/unload`
+- [x] **T1.5**: Write API route tests for `POST /api/deployments/{deployment}/unload`
   - Path-based deployment ID (no request body)
   - Returns 200 with status `"stopped"`
   - Returns 404 for unknown deployment name
   - Idempotent: unloading a deployment with no container returns `stopped`
 
-- [ ] **T1.6**: Write API route tests for `POST /api/proxy/{deployment}/{path:path}`
+- [x] **T1.6**: Write API route tests for `POST /api/proxy/{deployment}/{path:path}`
   - Proxy to healthy running deployment succeeds
   - Proxy to unknown deployment returns 404
   - Proxy to stopped deployment returns 400
   - Old `POST /v1/backends/{deployment}/{path:path}` no longer matches
 
-- [ ] **T1.7**: Write tests verifying `/v1/models` and `/v1/chat/completions` are unchanged
+- [x] **T1.7**: Write tests verifying `/v1/models` and `/v1/chat/completions` are unchanged
   - Confirms OpenAI-compatible routes were not disturbed by migration
 
 ### Phase 2: Reconciliation Layer
@@ -159,54 +159,54 @@ implemented as part of SEP-003:
 **Goal**: Replace existing routes with new `/api/`-prefixed routes, wired to reconciliation and lifecycle manager.
 
 #### Tasks
-- [ ] **T3.1**: Refactor route registration — remove `LoadModelRequest`/`UnloadModelRequest` body models
+- [x] **T3.1**: Refactor route registration — remove `LoadModelRequest`/`UnloadModelRequest` body models
   - File: `switchyard-api/src/switchyard/app.py`
   - Remove body-based request models; deployment ID comes from path parameter
 
-- [ ] **T3.2**: Implement `GET /api/deployments`
+- [x] **T3.2**: Implement `GET /api/deployments`
   - Returns all configured deployments from `config.deployments`
   - For each, look up in-memory state; derive `status: "stopped"` if absent
   - Attach current status to each entry
   - Call reconciliation before building the list
 
-- [ ] **T3.3**: Implement `GET /api/deployments/{deployment}`
+- [x] **T3.3**: Implement `GET /api/deployments/{deployment}`
   - Validate deployment exists in config
   - Reconcile the deployment
   - Return configured/resolved intent: model, runtime, host, placement, resolved store paths, runtime args at config layer
   - Attach current status summary (or `stopped` if no state)
 
-- [ ] **T3.4**: Implement `GET /api/deployments/{deployment}/status`
+- [x] **T3.4**: Implement `GET /api/deployments/{deployment}/status`
   - Validate deployment exists in config
   - Reconcile the deployment
   - Return live operational state: status, port, container_id, started_at, health
 
-- [ ] **T3.5**: Implement `POST /api/deployments/{deployment}/load`
+- [x] **T3.5**: Implement `POST /api/deployments/{deployment}/load`
   - Validate deployment exists in config
   - Resolve deployment
   - Reconcile before load (clears stale state or adopts already-running state)
   - Call `manager.load_model()`
   - Return 202 with deployment info
 
-- [ ] **T3.6**: Implement `POST /api/deployments/{deployment}/unload`
+- [x] **T3.6**: Implement `POST /api/deployments/{deployment}/unload`
   - Validate deployment exists in config
   - Resolve deployment
   - Reconcile before unload
   - If container already gone, return idempotent `stopped`
   - Otherwise call `manager.unload_model()`
 
-- [ ] **T3.7**: Implement `POST /api/proxy/{deployment}/{path:path}`
+- [x] **T3.7**: Implement `POST /api/proxy/{deployment}/{path:path}`
   - Reconcile the deployment before proxying
   - Resolve deployment ID → lifecycle state → container → backend URL → proxied path
   - Use existing proxy helpers (`_blocking_proxy`, `_streaming_proxy`)
   - Reject if deployment is not running
 
-- [ ] **T3.8**: Remove old routes
+- [x] **T3.8**: Remove old routes
   - `POST /deployments/load`, `POST /deployments/unload`
   - `GET /deployments`, `GET /deployments/{deployment}/status`
   - `POST /v1/backends/{deployment}/{path:path}`
   - Verify no other code paths reference old routes
 
-- [ ] **T3.9**: Update `_get_running_deployment` and `_backend_url` helpers
+- [x] **T3.9**: Update `_get_running_deployment` and `_backend_url` helpers
   - Remove references to removed routes
   - Keep helpers for `/v1/chat/completions` (unchanged)
 
@@ -215,7 +215,7 @@ implemented as part of SEP-003:
 **Goal**: All existing tests pass against new routes. Smoke tests aligned on deployment IDs and new paths.
 
 #### Tasks
-- [ ] **T4.1**: Update `test_api.py` — migrate existing tests to new `/api/` paths
+- [x] **T4.1**: Update `test_api.py` — migrate existing tests to new `/api/` paths
   - Old `TestDeploymentRoutes` class: update all paths to `/api/deployments/...`
   - Old `TestOpenAIProxy` backend tests: update to `/api/proxy/...`
   - Remove `LoadModelRequest`/`UnloadModelRequest` body usage; use path params
@@ -223,23 +223,23 @@ implemented as part of SEP-003:
     do not retain compatibility tests except explicit 404 assertions for
     removed routes
 
-- [ ] **T4.2**: Update `test_proxy.py` — migrate backend passthrough tests to `/api/proxy/`
+- [x] **T4.2**: Update `test_proxy.py` — migrate backend passthrough tests to `/api/proxy/`
   - Update all `/v1/backends/` references to `/api/proxy/`
 
-- [ ] **T4.3**: Update `test_app.py` if it references old routes
+- [x] **T4.3**: Update `test_app.py` if it references old routes
 
-- [ ] **T4.4**: Verify `GET /v1/models` tests still pass unchanged
+- [x] **T4.4**: Verify `GET /v1/models` tests still pass unchanged
 
-- [ ] **T4.5**: Verify `POST /v1/chat/completions` tests still pass unchanged
+- [x] **T4.5**: Verify `POST /v1/chat/completions` tests still pass unchanged
 
-- [ ] **T4.6**: Update operational helpers and manual smoke references
+- [x] **T4.6**: Update operational helpers and manual smoke references
   - File: `Makefile`
   - Update curl targets from old `/deployments/...` routes to new
     `/api/deployments/...` routes
   - Update any README or SEP manual smoke commands that still reference old
     lifecycle route paths
 
-- [ ] **T4.7**: Run full test suite
+- [x] **T4.7**: Run full test suite
   - `uv run pytest`
   - `uv run ruff check src tests --fix`
   - `uv run mypy src/switchyard`

--- a/switchyard-internal/sep/SEP-003-02-PLAN-deployment-lifecycle.md
+++ b/switchyard-internal/sep/SEP-003-02-PLAN-deployment-lifecycle.md
@@ -1,0 +1,337 @@
+# Deployment Lifecycle and API Namespace Migration
+
+**Title**: SEP-003 Deployment Lifecycle and API Namespace Migration
+**ID**: SEP-003-02-PLAN-deployment-lifecycle
+**Status**: Draft
+**Date**: 2026-05-03
+
+---
+
+## Implementation Approach
+
+SEP-003 has two objectives:
+
+1. **API namespace cleanup** — move Switchyard-native control-plane routes under `/api/`, keep OpenAI-compatible routes under `/v1/`, keep `/health` at root. Move backend passthrough from `/v1/backends/` to `/api/proxy/` because it is not part of the OpenAI-compatible surface.
+2. **Deployment lifecycle correctness** — replace body-based lifecycle routes with deployment-resource routes, add a deployment detail endpoint, reconcile in-memory state with Docker container state at request time, and handle stale/externally-removed containers gracefully.
+
+Status vocabulary uses the existing enum: `running`, `loading`, `stopped`, `error`. No new status values are introduced.
+
+Implementation follows TDD: tests first, then implementation. Route migration and reconciliation are interleaved so that new routes are always tested against working reconciliation logic.
+
+### Current vs. Target Route Map
+
+| Current Route | Target Route | Notes |
+|---|---|---|
+| `GET /health` | `GET /health` | No change |
+| `POST /deployments/load` | `POST /api/deployments/{deployment}/load` | Body-based → path-based |
+| `POST /deployments/unload` | `POST /api/deployments/{deployment}/unload` | Body-based → path-based |
+| `GET /deployments` | `GET /api/deployments` | Prefix only |
+| `GET /deployments/{deployment}/status` | `GET /api/deployments/{deployment}/status` | Prefix only |
+| *(not exists)* | `GET /api/deployments/{deployment}` | New: detail endpoint |
+| `POST /v1/backends/{deployment}/{path:path}` | `POST /api/proxy/{deployment}/{path:path}` | Move out of `/v1/` |
+| `GET /v1/models` | `GET /v1/models` | No change |
+| `POST /v1/chat/completions` | `POST /v1/chat/completions` | No change |
+
+### Out of Scope
+
+These routes are explicitly deferred to later SEPs and should not be
+implemented as part of SEP-003:
+
+| Route | Target SEP | Reason |
+|---|---|---|
+| `GET /api/hosts` | SEP-005 or SEP-007 | Host read APIs are separate from deployment lifecycle migration |
+| `GET /api/hosts/{host}/status` | SEP-007 | Host status depends on host resource discovery |
+| `GET /api/deployments/{deployment}/logs` | SEP-005 | Deployment diagnostics, not lifecycle route migration |
+| `POST /api/deployments/{deployment}/dry-run` | SEP-005 | Launch preview requires adapter preview contract and redaction policy |
+| `POST /api/deployments/{deployment}/validate` | SEP-005 | Static config validation is a diagnostics/read API concern |
+| `POST /api/deployments/{deployment}/preflight` | SEP-005 or SEP-007 | Dynamic Docker/host checks overlap host discovery and may be slower/side-effect-adjacent |
+| `GET /api/runtimes/{runtime}/schema` | SEP-004 | Runtime schema depends on typed runtime resolver hardening |
+
+## Task Breakdown
+
+### Phase 1: Tests — New Route Structure and Responses
+
+**Goal**: Failing tests that define the new `/api/` route shape, response bodies, and lifecycle behaviors.
+
+#### Tasks
+- [ ] **T1.1**: Write API route tests for new `/api/deployments` list endpoint
+  - File: `switchyard-api/tests/test_api.py` (new class `TestApiDeploymentRoutes`)
+  - `GET /api/deployments` returns all configured deployments with status
+  - Configured deployments with no lifecycle state get `status: "stopped"`
+  - Active deployments reflect their actual in-memory status
+  - Old `GET /deployments` no longer matches (returns 404)
+
+- [ ] **T1.2**: Write API route tests for `GET /api/deployments/{deployment}` detail endpoint
+  - Returns model, runtime, host references, placement, resolved store paths, runtime args at config layer, current status summary
+  - Does NOT return full env/volumes/Docker options/command arrays
+  - Returns 404 for unknown deployment name
+  - Configured deployment with no lifecycle state returns `status: "stopped"`
+
+- [ ] **T1.3**: Write API route tests for `GET /api/deployments/{deployment}/status` under `/api/`
+  - Returns live operational state for known deployments
+  - Returns 404 for unknown deployment
+  - Old path `GET /deployments/{deployment}/status` no longer matches
+
+- [ ] **T1.4**: Write API route tests for `POST /api/deployments/{deployment}/load`
+  - Path-based deployment ID (no request body)
+  - Returns 202 with deployment info on success
+  - Returns 404 for unknown deployment name
+  - Old body-based `POST /deployments/load` no longer matches
+
+- [ ] **T1.5**: Write API route tests for `POST /api/deployments/{deployment}/unload`
+  - Path-based deployment ID (no request body)
+  - Returns 200 with status `"stopped"`
+  - Returns 404 for unknown deployment name
+  - Idempotent: unloading a deployment with no container returns `stopped`
+
+- [ ] **T1.6**: Write API route tests for `POST /api/proxy/{deployment}/{path:path}`
+  - Proxy to healthy running deployment succeeds
+  - Proxy to unknown deployment returns 404
+  - Proxy to stopped deployment returns 400
+  - Old `POST /v1/backends/{deployment}/{path:path}` no longer matches
+
+- [ ] **T1.7**: Write tests verifying `/v1/models` and `/v1/chat/completions` are unchanged
+  - Confirms OpenAI-compatible routes were not disturbed by migration
+
+### Phase 2: Reconciliation Layer
+
+**Goal**: Request-time Docker state reconciliation via the lifecycle layer and host-aware Docker SDK factory, using Switchyard labels as the authoritative container lookup.
+
+#### Tasks
+- [ ] **T2.1**: Add reconciliation method to `LifecycleManager`
+  - File: `switchyard-api/src/switchyard/core/lifecycle.py`
+  - Method shape should accept enough deployment context to use the correct
+    Docker host, backend, internal port, and labels; a bare
+    `reconcile(deployment_name: str)` is insufficient if it cannot resolve the
+    target host/container context
+  - Candidate method:
+    `reconcile(deployment_name: str, resolved: ResolvedDeployment) -> DeploymentInfo | None`
+  - Looks up Docker container by Switchyard labels (not name), using
+    `switchyard.managed=true` and `switchyard.deployment={deployment_name}`
+  - Four outcomes:
+    - Container running and already in memory → preserve state, update status
+      to `running` if needed, return `DeploymentInfo`
+    - Container running and missing from memory → adopt it by rebuilding
+      `DeploymentInfo` from Docker labels, port bindings, backend metadata, and
+      resolved config; reserve the observed port in `PortAllocator`; return
+      `DeploymentInfo`
+    - Container exited/dead → clear in-memory state, cancel/remove any health
+      task for the deployment, release port, return `None`
+    - Container gone → clear in-memory state, cancel/remove any health task for
+      the deployment, release port, return `None`
+  - Uses a host-aware Docker client factory: `DockerClientFactory = Callable[[str | None], DockerClient]`. The factory resolves the correct Docker client from `resolved.docker_host` so multi-host behavior is preserved. A small helper in `switchyard.core.docker` provides client creation and label-based container lookup; `LifecycleManager` owns the state transitions.
+  - `LifecycleManager.__init__` accepts an optional `docker_client_factory` parameter. Tests inject a mock factory; production uses the factory from `create_app()`.
+
+- [ ] **T2.2**: Write unit tests for `LifecycleManager.reconcile()`
+  - File: `switchyard-api/tests/test_lifecycle.py` (new class `TestReconcile`)
+  - Test: reconcile running container → state preserved
+  - Test: reconcile running labeled container after API restart → state adopted,
+    observed port reserved, status `running`
+  - Test: reconcile exited container → state cleared, port released
+  - Test: reconcile dead container → state cleared, port released
+  - Test: reconcile gone container → state cleared, port released
+  - Test: reconcile stale deployment with health task → task cancelled/removed
+  - Test: reconcile unknown deployment → no-op, no error
+
+- [ ] **T2.3**: Wire reconciliation into `load_model`
+  - Before load: reconcile to clear stale state that could block a valid load
+  - If reconciliation finds a running labeled container for the deployment,
+    return/raise consistently with the existing "already deployed" behavior
+    after adoption
+  - If reconciliation finds exited/dead managed containers, ensure stale
+    containers are removed before `adapter.start()` so Docker name conflicts do
+    not block a valid load
+
+- [ ] **T2.4**: Wire reconciliation into `unload_model`
+  - Before unload: reconcile first
+  - If container already gone/exited: return idempotent success (state already cleared)
+
+- [ ] **T2.5**: Write lifecycle integration tests for reconciliation behavior
+  - File: `switchyard-api/tests/test_lifecycle.py`
+  - Test: API restart scenario → reconcile adopts running labeled container
+  - Test: load → reconcile clears stale → load succeeds
+  - Test: unload → reconcile finds gone container → returns without error
+  - Test: load → reconcile finds exited container → removes/replaces stale
+    managed container before starting a new one
+
+### Phase 3: Route Migration in `app.py`
+
+**Goal**: Replace existing routes with new `/api/`-prefixed routes, wired to reconciliation and lifecycle manager.
+
+#### Tasks
+- [ ] **T3.1**: Refactor route registration — remove `LoadModelRequest`/`UnloadModelRequest` body models
+  - File: `switchyard-api/src/switchyard/app.py`
+  - Remove body-based request models; deployment ID comes from path parameter
+
+- [ ] **T3.2**: Implement `GET /api/deployments`
+  - Returns all configured deployments from `config.deployments`
+  - For each, look up in-memory state; derive `status: "stopped"` if absent
+  - Attach current status to each entry
+  - Call reconciliation before building the list
+
+- [ ] **T3.3**: Implement `GET /api/deployments/{deployment}`
+  - Validate deployment exists in config
+  - Reconcile the deployment
+  - Return configured/resolved intent: model, runtime, host, placement, resolved store paths, runtime args at config layer
+  - Attach current status summary (or `stopped` if no state)
+
+- [ ] **T3.4**: Implement `GET /api/deployments/{deployment}/status`
+  - Validate deployment exists in config
+  - Reconcile the deployment
+  - Return live operational state: status, port, container_id, started_at, health
+
+- [ ] **T3.5**: Implement `POST /api/deployments/{deployment}/load`
+  - Validate deployment exists in config
+  - Resolve deployment
+  - Reconcile before load (clears stale state or adopts already-running state)
+  - Call `manager.load_model()`
+  - Return 202 with deployment info
+
+- [ ] **T3.6**: Implement `POST /api/deployments/{deployment}/unload`
+  - Validate deployment exists in config
+  - Resolve deployment
+  - Reconcile before unload
+  - If container already gone, return idempotent `stopped`
+  - Otherwise call `manager.unload_model()`
+
+- [ ] **T3.7**: Implement `POST /api/proxy/{deployment}/{path:path}`
+  - Reconcile the deployment before proxying
+  - Resolve deployment ID → lifecycle state → container → backend URL → proxied path
+  - Use existing proxy helpers (`_blocking_proxy`, `_streaming_proxy`)
+  - Reject if deployment is not running
+
+- [ ] **T3.8**: Remove old routes
+  - `POST /deployments/load`, `POST /deployments/unload`
+  - `GET /deployments`, `GET /deployments/{deployment}/status`
+  - `POST /v1/backends/{deployment}/{path:path}`
+  - Verify no other code paths reference old routes
+
+- [ ] **T3.9**: Update `_get_running_deployment` and `_backend_url` helpers
+  - Remove references to removed routes
+  - Keep helpers for `/v1/chat/completions` (unchanged)
+
+### Phase 4: Smoke Tests and Existing Test Updates
+
+**Goal**: All existing tests pass against new routes. Smoke tests aligned on deployment IDs and new paths.
+
+#### Tasks
+- [ ] **T4.1**: Update `test_api.py` — migrate existing tests to new `/api/` paths
+  - Old `TestDeploymentRoutes` class: update all paths to `/api/deployments/...`
+  - Old `TestOpenAIProxy` backend tests: update to `/api/proxy/...`
+  - Remove `LoadModelRequest`/`UnloadModelRequest` body usage; use path params
+  - Prune tests that only validate the removed body-based lifecycle API shape;
+    do not retain compatibility tests except explicit 404 assertions for
+    removed routes
+
+- [ ] **T4.2**: Update `test_proxy.py` — migrate backend passthrough tests to `/api/proxy/`
+  - Update all `/v1/backends/` references to `/api/proxy/`
+
+- [ ] **T4.3**: Update `test_app.py` if it references old routes
+
+- [ ] **T4.4**: Verify `GET /v1/models` tests still pass unchanged
+
+- [ ] **T4.5**: Verify `POST /v1/chat/completions` tests still pass unchanged
+
+- [ ] **T4.6**: Update operational helpers and manual smoke references
+  - File: `Makefile`
+  - Update curl targets from old `/deployments/...` routes to new
+    `/api/deployments/...` routes
+  - Update any README or SEP manual smoke commands that still reference old
+    lifecycle route paths
+
+- [ ] **T4.7**: Run full test suite
+  - `uv run pytest`
+  - `uv run ruff check src tests --fix`
+  - `uv run mypy src/switchyard`
+
+## Dependencies
+
+### Critical Path
+1. T1 (tests) → define target behavior
+2. T2 (reconciliation) → core correctness dependency for T3 routes
+3. T3 (route migration) → depends on T1 failing tests and T2 reconciliation
+4. T4 (test/helper updates) → depends on T3 being implemented
+
+### Parallel Work Streams
+- T1.1–T1.7 can be written in parallel (independent test classes)
+- T2.1–T2.2 can proceed while T1 is being written (unit tests for reconciliation don't depend on routes)
+
+## Risk Mitigation
+
+### Risk 1: Docker SDK Dependency in Reconciliation
+- **Description**: `LifecycleManager` currently does not import Docker SDK directly. Reconciliation needs to query containers by label.
+- **Mitigation**: Keep Docker SDK access behind a host-aware factory typed as `Callable[[str | None], DockerClient]`. The factory lives in `switchyard.core.docker` and resolves the correct client from `resolved.docker_host`. A small helper in that module also provides label-based container lookup (`switchyard.managed=true`, `switchyard.deployment={id}`). `LifecycleManager` owns all state-transition policy; no Docker logic scatters into adapters. Tests inject a mock factory at the fixture level.
+- **Owner**: Implementation
+- **Timeline**: T2.1
+
+### Risk 2: Breaking Existing Consumers
+- **Description**: Old routes (`POST /deployments/load`, `GET /deployments`, `POST /v1/backends/...`) are removed. Any external scripts or tests referencing them break.
+- **Mitigation**: All internal tests are updated in T4. The PLAN explicitly notes which routes are removed. No backward-compat redirects — clean break.
+- **Owner**: Implementation
+- **Timeline**: T3.8, T4
+
+### Risk 3: Reconciliation Performance
+- **Description**: Reconciling on every request adds Docker SDK overhead.
+- **Mitigation**: Reconciliation is targeted (one deployment per call, or batch for list). Docker SDK `containers.list(filter=...)` with label filter is lightweight. This is management API, not high-throughput inference path.
+- **Owner**: Implementation
+- **Timeline**: T2.1
+
+### Risk 4: Port Allocator State After Reconciliation Clears
+- **Description**: When reconciliation releases a port, a concurrent load request might allocate the same port before the old state is fully cleared.
+- **Mitigation**: Port release, health-task cancellation, and state removal are synchronous within reconciliation. `PortAllocator.release()` is already thread-safe. The lifecycle manager must not retain background tasks for cleared deployments.
+- **Owner**: Implementation
+- **Timeline**: T2.1
+
+## Validation Plan
+
+**Validation Commands**: See `AGENTS.md` Section "Quality Gates" for complete validation command list.
+
+```bash
+cd switchyard-api/
+uv run pytest
+uv run ruff check src tests --fix
+uv run mypy src/switchyard
+```
+
+### Success Criteria Validation
+- [ ] All tests pass: `uv run pytest` exits 0
+- [ ] Linting clean: `uv run ruff check src tests` exits 0
+- [ ] Type checking clean: `uv run mypy src/switchyard` exits 0
+- [ ] No regressions: `GET /v1/models`, `POST /v1/chat/completions`, `GET /health` unchanged
+- [ ] `GET /api/deployments` returns all configured deployments with derived status
+- [ ] `GET /api/deployments/{deployment}` returns config detail + status summary (no dry-run data)
+- [ ] `GET /api/deployments/{deployment}/status` returns live operational state
+- [ ] `POST /api/deployments/{deployment}/load` loads by path ID, returns 202
+- [ ] `POST /api/deployments/{deployment}/unload` unloads by path ID, idempotent on gone containers
+- [ ] `POST /api/proxy/{deployment}/{path:path}` proxies through running deployment
+- [ ] Old routes return 404 (`POST /deployments/load`, `GET /deployments`, `POST /v1/backends/...`)
+- [ ] Reconciliation adopts running Switchyard-labeled containers when API memory is empty and reserves the observed port
+- [ ] Reconciliation clears in-memory state and releases ports for gone/exited/dead containers
+- [ ] Reconciliation cancels/removes stale health tasks for cleared deployments
+- [ ] Reconciliation before load prevents stale state from blocking valid loads
+- [ ] Stale exited/dead managed containers do not cause Docker name conflicts on load
+- [ ] Makefile/manual smoke references use new `/api/deployments/...` lifecycle routes
+- [ ] Ruff and mypy pass with no errors
+
+---
+
+## Decision Log
+
+| ID | Decision | Reason | Status |
+|---|---|---|---|
+| D1 | Switchyard-native control-plane routes move under `/api/` | Separates first-party management API traffic from OpenAI-compatible inference routes and prevents route collisions with the future Web UI | Agreed |
+| D2 | OpenAI-compatible inference routes remain under `/v1/` | Keeps `/v1/` reserved for client-facing OpenAI-compatible behavior such as model discovery and chat completions | Agreed |
+| D3 | `/health` remains at root | Operational liveness endpoints are commonly exposed outside product API namespaces and do not belong to either `/api/` or `/v1/` | Agreed |
+| D4 | Body-based lifecycle actions are replaced by deployment-resource routes with no compatibility aliases | Deployment is the lifecycle unit after SEP-002; a clean break avoids carrying obsolete API shape during early project development | Agreed |
+| D5 | Backend passthrough moves from `/v1/backends/{deployment}/{path:path}` to `/api/proxy/{deployment}/{path:path}` | Passthrough is Switchyard management/proxy surface, not OpenAI-compatible API surface | Agreed |
+| D6 | SEP-003 uses the existing status enum: `running`, `loading`, `stopped`, `error` | Avoids unnecessary state-model migration; configured deployments without live state derive `stopped` | Agreed |
+| D7 | `GET /api/deployments` returns all configured deployments with current/derived status attached | The Web UI must show stopped deployments and offer lifecycle actions; active-only discovery remains `/v1/models` | Agreed |
+| D8 | `GET /api/deployments/{deployment}` returns deployment detail plus a small status summary, not dry-run output | Detail answers what Switchyard thinks the deployment is; generated Docker options, commands, env, volumes, and redaction policy are deferred to future dry-run work | Agreed |
+| D9 | Docker reconciliation runs at request time, not in a background reconciler | Keeps SEP-003 deterministic and scoped while correcting stale state before lifecycle/status/proxy operations | Agreed |
+| D10 | Reconciliation uses Switchyard labels as the authoritative container marker | Container names are for human readability; labels identify Switchyard-managed containers across host/runtime naming changes | Agreed |
+| D11 | Reconciliation auto-corrects stale external removal or exited/dead managed containers | Clearing in-memory state, releasing ports, and reporting `stopped` is less surprising than requiring manual state repair | Agreed |
+| D12 | Request-time reconciliation is owned by `LifecycleManager` using a host-aware Docker client factory, not `BackendAdapter.reconcile()` | Reconciliation repairs Switchyard lifecycle state using cross-adapter labels, ports, and health-task cleanup. Keeping it in lifecycle avoids duplicating Docker label lookup and stale-state policy in every adapter. The factory resolves the correct Docker client from `ResolvedDeployment.docker_host` so multi-host behavior is preserved | Agreed |
+
+---
+
+This plan serves as the single source of truth during implementation. Update status as work progresses.

--- a/switchyard-internal/sep/SEP-003-02-PLAN-deployment-lifecycle.md
+++ b/switchyard-internal/sep/SEP-003-02-PLAN-deployment-lifecycle.md
@@ -2,7 +2,7 @@
 
 **Title**: SEP-003 Deployment Lifecycle and API Namespace Migration
 **ID**: SEP-003-02-PLAN-deployment-lifecycle
-**Status**: Draft
+**Status**: Complete
 **Date**: 2026-05-03
 
 ---
@@ -294,24 +294,24 @@ uv run mypy src/switchyard
 ```
 
 ### Success Criteria Validation
-- [ ] All tests pass: `uv run pytest` exits 0
-- [ ] Linting clean: `uv run ruff check src tests` exits 0
-- [ ] Type checking clean: `uv run mypy src/switchyard` exits 0
-- [ ] No regressions: `GET /v1/models`, `POST /v1/chat/completions`, `GET /health` unchanged
-- [ ] `GET /api/deployments` returns all configured deployments with derived status
-- [ ] `GET /api/deployments/{deployment}` returns config detail + status summary (no dry-run data)
-- [ ] `GET /api/deployments/{deployment}/status` returns live operational state
-- [ ] `POST /api/deployments/{deployment}/load` loads by path ID, returns 202
-- [ ] `POST /api/deployments/{deployment}/unload` unloads by path ID, idempotent on gone containers
-- [ ] `POST /api/proxy/{deployment}/{path:path}` proxies through running deployment
-- [ ] Old routes return 404 (`POST /deployments/load`, `GET /deployments`, `POST /v1/backends/...`)
-- [ ] Reconciliation adopts running Switchyard-labeled containers when API memory is empty and reserves the observed port
-- [ ] Reconciliation clears in-memory state and releases ports for gone/exited/dead containers
-- [ ] Reconciliation cancels/removes stale health tasks for cleared deployments
-- [ ] Reconciliation before load prevents stale state from blocking valid loads
-- [ ] Stale exited/dead managed containers do not cause Docker name conflicts on load
-- [ ] Makefile/manual smoke references use new `/api/deployments/...` lifecycle routes
-- [ ] Ruff and mypy pass with no errors
+- [x] All tests pass: `uv run pytest` exits 0
+- [x] Linting clean: `uv run ruff check src tests` exits 0
+- [x] Type checking clean: `uv run mypy src/switchyard` exits 0
+- [x] No regressions: `GET /v1/models`, `POST /v1/chat/completions`, `GET /health` unchanged
+- [x] `GET /api/deployments` returns all configured deployments with derived status
+- [x] `GET /api/deployments/{deployment}` returns config detail + status summary (no dry-run data)
+- [x] `GET /api/deployments/{deployment}/status` returns live operational state
+- [x] `POST /api/deployments/{deployment}/load` loads by path ID, returns 202
+- [x] `POST /api/deployments/{deployment}/unload` unloads by path ID, idempotent on gone containers
+- [x] `POST /api/proxy/{deployment}/{path:path}` proxies through running deployment
+- [x] Old routes return 404 (`POST /deployments/load`, `GET /deployments`, `POST /v1/backends/...`)
+- [x] Reconciliation adopts running Switchyard-labeled containers when API memory is empty and reserves the observed port
+- [x] Reconciliation clears in-memory state and releases ports for gone/exited/dead containers
+- [x] Reconciliation cancels/removes stale health tasks for cleared deployments
+- [x] Reconciliation before load prevents stale state from blocking valid loads
+- [x] Stale exited/dead managed containers do not cause Docker name conflicts on load
+- [x] Makefile/manual smoke references use new `/api/deployments/...` lifecycle routes
+- [x] Ruff and mypy pass with no errors
 
 ---
 

--- a/switchyard-internal/sep/SEP-003-02-PLAN-deployment-lifecycle.md
+++ b/switchyard-internal/sep/SEP-003-02-PLAN-deployment-lifecycle.md
@@ -98,7 +98,7 @@ implemented as part of SEP-003:
 **Goal**: Request-time Docker state reconciliation via the lifecycle layer and host-aware Docker SDK factory, using Switchyard labels as the authoritative container lookup.
 
 #### Tasks
-- [ ] **T2.1**: Add reconciliation method to `LifecycleManager`
+- [x] **T2.1**: Add reconciliation method to `LifecycleManager`
   - File: `switchyard-api/src/switchyard/core/lifecycle.py`
   - Method shape should accept enough deployment context to use the correct
     Docker host, backend, internal port, and labels; a bare
@@ -122,7 +122,7 @@ implemented as part of SEP-003:
   - Uses a host-aware Docker client factory: `DockerClientFactory = Callable[[str | None], DockerClient]`. The factory resolves the correct Docker client from `resolved.docker_host` so multi-host behavior is preserved. A small helper in `switchyard.core.docker` provides client creation and label-based container lookup; `LifecycleManager` owns the state transitions.
   - `LifecycleManager.__init__` accepts an optional `docker_client_factory` parameter. Tests inject a mock factory; production uses the factory from `create_app()`.
 
-- [ ] **T2.2**: Write unit tests for `LifecycleManager.reconcile()`
+- [x] **T2.2**: Write unit tests for `LifecycleManager.reconcile()`
   - File: `switchyard-api/tests/test_lifecycle.py` (new class `TestReconcile`)
   - Test: reconcile running container → state preserved
   - Test: reconcile running labeled container after API restart → state adopted,
@@ -133,7 +133,7 @@ implemented as part of SEP-003:
   - Test: reconcile stale deployment with health task → task cancelled/removed
   - Test: reconcile unknown deployment → no-op, no error
 
-- [ ] **T2.3**: Wire reconciliation into `load_model`
+- [x] **T2.3**: Wire reconciliation into `load_model`
   - Before load: reconcile to clear stale state that could block a valid load
   - If reconciliation finds a running labeled container for the deployment,
     return/raise consistently with the existing "already deployed" behavior
@@ -142,11 +142,11 @@ implemented as part of SEP-003:
     containers are removed before `adapter.start()` so Docker name conflicts do
     not block a valid load
 
-- [ ] **T2.4**: Wire reconciliation into `unload_model`
+- [x] **T2.4**: Wire reconciliation into `unload_model`
   - Before unload: reconcile first
   - If container already gone/exited: return idempotent success (state already cleared)
 
-- [ ] **T2.5**: Write lifecycle integration tests for reconciliation behavior
+- [x] **T2.5**: Write lifecycle integration tests for reconciliation behavior
   - File: `switchyard-api/tests/test_lifecycle.py`
   - Test: API restart scenario → reconcile adopts running labeled container
   - Test: load → reconcile clears stale → load succeeds


### PR DESCRIPTION
### Summary

Migrate Switchyard-native control-plane routes under `/api/`, move backend passthrough from `/v1/backends/` to `/api/proxy/`, and add request-time Docker state reconciliation to deployment lifecycle operations.

### Changes

**Route migration**
- Lifecycle routes now under `/api/deployments/{deployment}/{action}` (path-based, no request body)
- New `GET /api/deployments/{deployment}` detail endpoint returning config-level intent + status summary
- Backend passthrough moved from `POST /v1/backends/{deployment}/{path:path}` to `POST /api/proxy/{deployment}/{path:path}`
- OpenAI-compatible routes (`/v1/models`, `/v1/chat/completions`) and `GET /health` unchanged
- Old routes removed (clean break, return 404)

**Deployment reconciliation**
- Request-time Docker state reconciliation via `LifecycleManager.reconcile()` using Switchyard labels as authoritative container markers
- Four outcomes handled: running (adopt/preserve), exited/dead (clear), gone (clear), unknown (no-op)
- Reconciliation runs before every lifecycle/status/proxy operation to prevent stale state
- Stale exited/dead managed containers removed before load to avoid Docker name conflicts
- Health tasks cancelled and ports released when reconciliation clears state
- Host-aware Docker client factory resolves correct Docker host from `ResolvedDeployment.docker_host`

**Tests**
- Full test coverage for new `/api/` routes (T1.1–T1.7)
- Unit tests for reconciliation layer (T2.2)
- Integration tests for reconciliation + lifecycle wiring (T2.5)
- Existing tests migrated to new paths (T4.1–T4.4)
- All quality gates pass: `pytest`, `ruff`, `mypy`

**Operational**
- Makefile targets updated to new `/api/deployments/...` lifecycle routes

### Risks

- **Breaking change**: Old routes (`POST /deployments/load`, `GET /deployments`, `POST /v1/backends/...`) are removed with no backward-compat redirects. Any external scripts using these paths will need updating.